### PR TITLE
job #7519 We use the dap plugin's feature.xml to get a list of the

### DIFF
--- a/utilities/build/configure_external_dependencies.sh
+++ b/utilities/build/configure_external_dependencies.sh
@@ -3,12 +3,6 @@
 #-------------------------------------------------------------------------------
 # Functions
 #-------------------------------------------------------------------------------
-error()
-{
-    echo Error! $1
-    exit 1
-}
-
 #
 # Make sure the caller put the required binaries in place
 #
@@ -19,42 +13,48 @@ get_user_supplied_binaries ()
     mkdir $user_supplied_files
     
     # Get the need files from the revision control folder
-    cp ${GIT_REPO_ROOT}/packaging/* $user_supplied_files
+    cp -rf ${GIT_REPO_ROOT}/packaging/* $user_supplied_files
     
     cd $user_supplied_files
+    missing_files=""
     if [ ! -e ./xtumlmc_build.exe ]; then
-        error "Missing ./xtumlmc_build.exe"
+        missing_files+="./xtumlmc_build.exe"
     fi
 
     if [ ! -e ./gen_erate.exe ]; then
-        error "Missing ./gen_erate.exe"
+        missing_files+="./gen_erate.exe"
     fi
 
     if [ ! -e  ./vgalaxy8.vr ]; then
-        error "Missing ./vgalaxy8.vr"
+        missing_files+="./vgalaxy8.vr"
     fi
 
     if [ ! -e  ./vgal8c.dll ]; then
-        error "Missing ./vgal8c.dll"
+        missing_files+="./vgal8c.dll"
     fi
 
     if [ ! -e  ./msvcrt.dll ]; then
-        error "Missing ./msvcrt.dll"
+        missing_files+="./msvcrt.dll"
     fi
 
     if [ ! -e  ./mc3020_doc.zip ]; then
-        error "Missing ./mc3020_doc.zip"
+        missing_files+="./mc3020_doc.zip"
     fi
     
     if [ ! -e  ./mcmc ]; then
-        error "Missing ./mcmc"
+        missing_files+="./mcmc"
     fi
 
     if [ ! -e  ./mcmc.exe ]; then
-        error "Missing ./mcmc.exe"
+        missing_files+="./mcmc.exe"
     fi
     
+    if [ missing_files != ""]; then
+       echo -e "Error!: Missing files: $missing_files"
+       return 1
+    fi
     echo -e "Exiting configure_external_dependencies.sh::get_user_supplied_binaries"
+    return 0
 }
 
 configure_dap()
@@ -211,14 +211,15 @@ mcvhdl_src=${BUILD_DIR}/org.xtuml.bp.mc.vhdl.source
 mc3020_help=${BUILD_DIR}/org.xtuml.help.bp.mc
 
 get_user_supplied_binaries
+if ["$?" == "0"];  then
+  configure_mcc_src
+  configure_mcc_bin
+  configure_mcsystemc_src
+  configure_mccpp_src
+  configure_vhdl_src
 
-configure_mcc_src
-configure_mcc_bin
-configure_mcsystemc_src
-configure_mccpp_src
-configure_vhdl_src
-
-configure_dap
+  configure_dap
+fi
 
 cd ${BUILD_DIR}
 

--- a/utilities/build/create_bp_release.sh
+++ b/utilities/build/create_bp_release.sh
@@ -142,13 +142,18 @@ function create_build {
     # Generate list of modules needing verification
     all_modules="${internal_modules} ${plugin_modules} ${RELEASE_PKG} ${all_feature_modules} ${model_compiler_modules}"
 
+	verify_rval="0"
     for module in $all_modules; do
         echo "Verifying checkout of $module"
         verify_checkout
-        verify_rval="$?"
+        # We let the loop continue to report all possible errors, but we don't
+        # want to reset the error condition when one is present
+        if [ "$verify_rval" != "0" ]; then
+          verify_rval="$?"
+        fi
     done
 
-    if [ "$verify_rval" != "1" ]; then
+    if [ "$verify_rval" != "0" ]; then
         zip_distribution
     fi
 	echo -e "Exiting create_bp_release.sh::create_build"

--- a/utilities/build/create_release_functions.sh
+++ b/utilities/build/create_release_functions.sh
@@ -77,9 +77,10 @@ function verify_checkout {
     dir_count=`ls ${module} | wc -l`
 
     if [ ${dir_count} -le 1 ]; then
-        echo -e "Error checking out ${module} with tag: ${BRANCH}"
+        echo -e "Error in create_release_functions.sh::verify_checkout while checking out ${module} with tag: ${BRANCH}"
         return 1
     fi
+    return 0
 }
 
 function get_required_modules {
@@ -87,6 +88,7 @@ function get_required_modules {
     chown -R ${SHELLUSER} ${RELEASE_PKG}
 
     if [ -e ${RELEASE_PKG}/feature.xml ]; then
+    	dos2unix $BUILD_DIR/$RELEASE_PKG/feature.xml
         plugin_modules=`grep "<plugin id=" $BUILD_DIR/$RELEASE_PKG/feature.xml | awk -F"=" '{printf("%s\n", $2)}' | sed s/\"// | sed s/\"//`
         release_version=`awk -F"\"" '{if (/[0-9]\.[0-9]\.[0-9]/) {print $2; exit;}}' ${BUILD_DIR}/${RELEASE_PKG}/feature.xml`
         plugin_modules="${plugin_modules} ${independent_modules}"


### PR DESCRIPTION
plugins to build.  I made a change to assure that this file is in
unix-style format to assure CR LF issues between windows and linux to
not occur.  Without this what happened is that there were embedded CR in
the file that caused the bash scripts to fail.