### PR TITLE
job #7519 Call compilation from the create_bp_realse.sh script instead

### DIFF
--- a/utilities/build/configure_external_dependencies.sh
+++ b/utilities/build/configure_external_dependencies.sh
@@ -49,7 +49,7 @@ get_user_supplied_binaries ()
         missing_files+="./mcmc.exe"
     fi
     
-    if [ missing_files != ""]; then
+    if [ $missing_files != ""]; then
        echo -e "Error!: Missing files: $missing_files"
        return 1
     fi
@@ -211,7 +211,7 @@ mcvhdl_src=${BUILD_DIR}/org.xtuml.bp.mc.vhdl.source
 mc3020_help=${BUILD_DIR}/org.xtuml.help.bp.mc
 
 get_user_supplied_binaries
-if ["$?" == "0"];  then
+if [ "$?" = "0" ];  then
   configure_mcc_src
   configure_mcc_bin
   configure_mcsystemc_src

--- a/utilities/build/create_bp_release.sh
+++ b/utilities/build/create_bp_release.sh
@@ -14,7 +14,6 @@
 # will be delivered
 function jar_distribution {
 	echo -e "Entering create_bp_release.sh::jar_distribution"    
-    compile_modules
 
     cd $BUILD_DIR
 
@@ -153,8 +152,13 @@ function create_build {
         fi
     done
 
-    if [ "$verify_rval" != "0" ]; then
-        zip_distribution
+	# don't bother compiling zipping
+    if [ "$verify_rval" = "0" ]; then
+    	compile_modules    	
+    	if [ "$?" != "0" ]; then
+    	  # don't bother zipping if there are compile errors
+          zip_distribution
+        fi
     fi
 	echo -e "Exiting create_bp_release.sh::create_build"
 }

--- a/utilities/build/create_release_functions.sh
+++ b/utilities/build/create_release_functions.sh
@@ -169,6 +169,7 @@ function build_modules {
 function compile_modules {
 	echo -e "Entering create_release_functions.sh::compile_modules"
 
+	compile_result = "0"
     build_modules
 
     # Have to make sure the plugin compilation is ordered properly.
@@ -211,12 +212,14 @@ function compile_modules {
             failure_count=`grep -c -i -w "FAILURE" ${compile_log_dir}/${module}_compile.log`
 
             if [ ${error_count} -gt 0 ] || [ ${failed_count} -gt 0 ] || [ ${failure_count} -gt 0 ]; then
+            	compile_result = "1"
                 compile_log_path=`cygpath -m ${compile_log_dir}/${module}_compile.log`
                 echo -e "Errors or failures found during the compilation of ${module}. Check ${compile_log_path}.\n" >> ${error_file}
             fi
         fi
     done
 	echo -e "Exiting create_release_functions.sh::compile_modules"
+	return $compile_result
 }
 
 


### PR DESCRIPTION
of under the jar_distribution function to improve readability and dlow
of control.  Additionally, in this same vain, if plugin validation fails
don't bother compiling, and if compilation fails don't bother
jar'ing/zipping.