### PR TITLE
7597 simply post install

### DIFF
--- a/src/installer/CLI.bat
+++ b/src/installer/CLI.bat
@@ -1,5 +1,11 @@
 @echo off
 
+:: This command gets the location of the directory that holds this script.  We
+:: use this to set up the rest of the paths for launching.  If you want to copy
+:: this script elsewhere, you should modify BPHOMEDIR to explicitly set the 
+:: location where BridgePoint is installed to.
+set BPHOMEDIR=%~dp0\..
+
 ::Check that a valid argument is specified
 if "%1"=="Build" goto ArgsOK
 if "%1"=="Execute" goto ArgsOK
@@ -33,7 +39,7 @@ if not "%WORKSPACE%"=="" goto RunApp
   :: choose to set the value in the environment, or modify the following line to
   :: point to the correct location.
   ::
-  set WORKSPACE=%~d0\xtuml\BridgePoint\workspace
+  set WORKSPACE=%~dp0\..\workspace
 goto RunApp
 
 :RunApp
@@ -42,9 +48,6 @@ echo Using WORKSPACE=%WORKSPACE%
 ::
 :: DO NOT MODIFY ANY OF THE FOLLOWING LINES.
 ::
-set ORIGINAL_PATH=%PATH%
-set PATH=%PATH%;%~d0\xtuml\BridgePoint\tools\docgen\docbook
-set BPHOMEDIR=%~d0\xtuml\BridgePoint
 set LAUNCHER=%BPHOMEDIR%\eclipse\plugins\org.eclipse.equinox.launcher_1.2.0.v20110502.jar
 set APPLICATION=org.xtuml.bp.cli.%1
 set BP_JVM=%BPHOMEDIR%\jre\bin\java.exe
@@ -68,6 +71,5 @@ echo %COMMAND%
 
 :: Change back to users directory and restore the PATH
 popd
-set PATH=%ORIGINAL_PATH%
 
 :exit

--- a/src/installer/CLI.sh
+++ b/src/installer/CLI.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
-BPHOMEDIR="C:/xtuml/BridgePoint"
+# This command gets the location of the directory that holds this script.  We
+# use this to set up the rest of the paths for launching.  If you want to copy
+# this script elsewhere, you should modify BPHOMEDIR to explicitly set the 
+# location where BridgePoint is installed to.
+DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+BPHOMEDIR="$DIR/.."
 
 function die() {
   echo -e $@
@@ -53,14 +58,9 @@ fi
 #
 # DO NOT MODIFY ANY OF THE FOLLOWING LINES.
 #
-export ORIGINAL_PATH=$PATH
-export PATH=$PATH:$BPHOMEDIR/tools/docgen/docbook
 LAUNCHER="$BPHOMEDIR/eclipse/plugins/org.eclipse.equinox.launcher_1.2.0.v20110502.jar"
 APPLICATION="org.xtuml.bp.cli.$1"
 
 $BPHOMEDIR/jre/bin/java  -d32 -Xms256m -Xmx1g -XX:MaxPermSize=256m -jar $LAUNCHER -clean -noSplash -product org.xtuml.bp.pkg.BridgePoint -data $WORKSPACE -application $APPLICATION $2 "$3" $4 "$5" $6 "$7" $8 "$9"
-
-# Restore the path
-export PATH=$ORIGINAL_PATH
 
 exit 0

--- a/src/installer/Launcher.bat
+++ b/src/installer/Launcher.bat
@@ -1,11 +1,14 @@
 @echo off
 
+:: This command gets the location of the directory that holds this script.  We
+:: use this to set up the rest of the paths for launching.  If you want to copy
+:: this script elsewhere, you should modify BPHOMEDIR to explicitly set the 
+:: location where BridgePoint is installed to.
+set BPHOMEDIR=%~dp0\..
+
 ::
 :: DO NOT MODIFY ANY OF THE FOLLOWING LINES.
 ::
-set ORIGINAL_PATH=%PATH%
-set PATH=%PATH%;%~d0\xtuml\BridgePoint\tools\docgen\docbook
-set BPHOMEDIR=%~d0\xtuml\BridgePoint
 set BP_JVM=%BPHOMEDIR%\jre\bin\javaw.exe
 
 :: Check for fonts that trip up generator
@@ -19,6 +22,3 @@ call %BPHOMEDIR%\MinGW\mingwgnu.bat
 :: Run BridgePoint
 cd %BPHOMEDIR%\eclipse
 start eclipse.exe -vm %BP_JVM% %1 %2 %3 %4 %5 %6 %7 %8 %9
-
-:: Restore the PATH
-set PATH=%ORIGINAL_PATH%

--- a/src/installer/Launcher.sh
+++ b/src/installer/Launcher.sh
@@ -1,15 +1,16 @@
 #!/bin/bash
-BPHOMEDIR="C:/xtuml/BridgePoint"
+# This command gets the location of the directory that holds this script.  We
+# use this to set up the rest of the paths for launching.  If you want to copy
+# this script elsewhere, you should modify BPHOMEDIR to explicitly set the 
+# location where BridgePoint is installed to.
+DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+BPHOMEDIR="$DIR/.."
 
 #
 # DO NOT MODIFY ANY OF THE FOLLOWING LINES.
 #
-export ORIGINAL_PATH=$PATH
-export PATH=$PATH:$BPHOMEDIR/tools/docgen/docbook
 export GDK_NATIVE_WINDOWS=true
 export BP_JVM=$BPHOMEDIR/jre/lib/i386/client/libjvm.so
 
 $BPHOMEDIR/eclipse/eclipse -vm $BP_JVM $1 $2 $3 $4 $5 $6 $7 $8 $9
 
-# Restore the path
-export PATH=$ORIGINAL_PATH

--- a/src/installer/post_install_script.bat
+++ b/src/installer/post_install_script.bat
@@ -1,55 +1,14 @@
 @echo off
 
 echo Starting post-install script
-SET BPVER=5.0.0
-
-:: Localization Note: To support UNICODE paths for Source, Target, or MIP 
-:: location, the scripts should ignore the command line $1, $2 arguments and use
-:: the MG_INSTALL_TARGET and MG_INSTALL_MSI_COMMANDER environment variables 
-:: instead.
-
 SET TARGET=%1
 SET ECLIPSEDIR=%2
 
-:: Update the following files to reflect the target location provided by the user...
-echo Updating install path in config files
-SET BP_PATH=xtuml\BridgePoint
-SET TGT_PATH=%TARGET:~3%
-"%TARGET%\tools\update_text" "%TARGET%\extras\Launcher.bat" "%BP_PATH%" "%TGT_PATH%"
-"%TARGET%\tools\update_text" "%TARGET%\extras\CLI.bat" "%BP_PATH%" "%TGT_PATH%"
-SET BP_PATH=C:\xtuml\BridgePoint
-SET TGT_PATH=%TARGET%
-"%TARGET%\tools\update_text" -c "%TARGET%\tools\docgen\docgen.xsl" "%BP_PATH%" "%TGT_PATH%"
-"%TARGET%\tools\update_text" "%TARGET%\MinGW\mingwgnu.bat" "%BP_PATH%" "%TGT_PATH%"
-IF NOT EXIST "%TARGET%\eclipse\eclipse.ini" GOTO NoBPEclipse
-  "%TARGET%\tools\update_text" "%TARGET%\eclipse\eclipse.ini" "%BP_PATH%" "%TGT_PATH%"
-  :NoBPEclipse
-echo Done
-
-:: Move the eclipse-related files from "extras/" to the eclipse directory specified in "extras/eclipsedir.txt".  This will either
-:: be the eclipse installation under the BP install, or the users pre-existing eclipse installation.
+:: Move the eclipse-related files from "extras/" to the eclipse directory specified in ECLIPSEDIR.
 echo Updating Eclipse configuration
-IF EXIST "%ECLIPSEDIR%/links" GOTO LinksDirReady
-  echo Creating %ECLIPSEDIR%/links
-  MKDIR "%ECLIPSEDIR%/links"
-  :LinksDirReady
 echo Eclipse installation is at: %ECLIPSEDIR%
 MOVE "%TARGET%\extras\Launcher.bat" "%ECLIPSEDIR%/"
 MOVE "%TARGET%\extras\CLI.bat" "%ECLIPSEDIR%/"
-GOTO EclipseUpdateDone
-:EclipseUpdateError
-echo Error during discovery of eclipse location.  %ECLIPSECFGFILE% does not exist.
-:EclipseUpdateDone
-echo Done
-
-:: Show release notes or not depending on their selection in the installer.
-echo Release notes display (or not)
-SET RNFLAGFILE=%TARGET%\extras\rnflag.txt
-IF EXIST "%RNFLAGFILE%" ECHO Found the Release notes flag file %RNFLAGFILE%
-START iexplore "file://%TARGET%\eclipse\plugins\org.xtuml.bp.doc_%BPVER%\ReleaseNotes\HTML\ReleaseNotes.htm"
-DEL "%RNFLAGFILE%"
-GOTO ReleaseNotesDone
-:ReleaseNotesDone
 echo Done
 
 ::Run the vcredist_x86.exe to update the runtime libraries. The redist package

--- a/src/installer/post_install_script.sh
+++ b/src/installer/post_install_script.sh
@@ -36,25 +36,7 @@ configure_mc_files()
 TARGET=$1
 ECLIPSEDIR=$2
 
-# Update the following files to reflect the target location provided by the user...
-echo "Updating install path in config files"
-BP_PATH=C:/xtuml/BridgePoint
-sed -e 's;'"$BP_PATH"';'"$TARGET"';g' "$TARGET/eclipse/Launcher.sh" > "$TARGET/eclipse/Launcher.sh.tmp"
-chmod --reference="$TARGET/eclipse/Launcher.sh" "$TARGET/eclipse/Launcher.sh.tmp"
-mv -f "$TARGET/eclipse/Launcher.sh.tmp" "$TARGET/eclipse/Launcher.sh"
-sed -e 's;'"$BP_PATH"';'"$TARGET"';g' "$TARGET/eclipse/CLI.sh" > "$TARGET/eclipse/CLI.sh.tmp"
-chmod --reference="$TARGET/eclipse/CLI.sh" "$TARGET/eclipse/CLI.sh.tmp"
-mv -f "$TARGET/eclipse/CLI.sh.tmp" "$TARGET/eclipse/CLI.sh"
-sed -e 's;'"$BP_PATH"';'"$TARGET"';g' "$TARGET/tools/docgen/docgen.xsl" > "$TARGET/tools/docgen/docgen.xsl.tmp"
-chmod --reference="$TARGET/tools/docgen/docgen.xsl" "$TARGET/tools/docgen/docgen.xsl.tmp"
-mv -f "$TARGET/tools/docgen/docgen.xsl.tmp" "$TARGET/tools/docgen/docgen.xsl"
 chmod 775 "$TARGET/tools/docgen/docgen"
-if [ -f "$TARGET/eclipse/eclipse.ini" ]
-then
-  sed -e 's;'"$BP_PATH"';'"$TARGET"';g' "$TARGET/eclipse/eclipse.ini" > "$TARGET/eclipse/eclipse.ini.tmp"
-  chmod --reference="$TARGET/eclipse/eclipse.ini" "$TARGET/eclipse/eclipse.ini.tmp"
-  mv -f "$TARGET/eclipse/eclipse.ini.tmp" "$TARGET/eclipse/eclipse.ini"
-fi
 
 # Make sure these key files are in UNIX format
 tr -d '\r' < "$TARGET/eclipse/eclipse.ini" > "$TARGET/eclipse/eclipse.d2u"
@@ -97,15 +79,5 @@ chmod +x "$TARGET/jre/bin/java"
 chmod +x "$TARGET/eclipse/eclipse"
 "$TARGET/eclipse/eclipse" -vm $BP_JVM -initialize &
 echo "Done"
-
-# Show release notes or not depending on their selection in the installer.
-echo "Release notes display (or not)"
-SHOWRN=true
-if [ $SHOWRN ]
-then
-	echo "Found the Release notes flag file $RNFLAGFILE"
-	firefox "$TARGET/eclipse/plugins/org.xtuml.bp.doc_$BPVER/ReleaseNotes/HTML/ReleaseNotes.htm" &
-fi
-echo Done
 
 echo Post-install script complete

--- a/src/org.xtuml.bp.docgen/src/org/xtuml/bp/docgen/generator/Generator.java
+++ b/src/org.xtuml.bp.docgen/src/org/xtuml/bp/docgen/generator/Generator.java
@@ -64,6 +64,7 @@ public class Generator extends Task {
     public static final String DOCGEN_DIR = "/tools/docgen/"; //$NON-NLS-1$
     public static final String DOCGEN_EXE = "docgen"; //$NON-NLS-1$
     public static final String XSLTPROC_EXE = "docbook/xsltproc"; //$NON-NLS-1$
+    public static final String XHTMLFILES = DOCGEN_DIR + "docbook/docbook-xsl-1.75.1/xhtml/"; //$NON-NLS-1$
     public static final String DOC_DIR = "doc/"; //$NON-NLS-1$
     public static final String DOCGEN_INPUT = "a.xtuml"; //$NON-NLS-1$
     public static final String DOC_HTML = "doc.html"; //$NON-NLS-1$
@@ -376,8 +377,8 @@ public class Generator extends Task {
         throws IOException, RuntimeException, CoreException, InterruptedException 
     {
         // Call docgen.exe 
-        String homedir = System.getenv("ECLIPSE_HOME"); //$NON-NLS-1$
-        String app = homedir + "/.." + DOCGEN_DIR + DOCGEN_EXE;
+        String homedir = System.getenv("BPHOMEDIR"); //$NON-NLS-1$
+        String app = homedir + DOCGEN_DIR + DOCGEN_EXE;
         String outputfile = DOC_XML;
         File output = new File(workingDir + outputfile);
         File input = new File(workingDir + DOCGEN_INPUT);
@@ -408,8 +409,9 @@ public class Generator extends Task {
         throws IOException, RuntimeException, CoreException, InterruptedException 
     {
         // Run xsltproc to convert doc.xml into doc.html
-        String homedir = System.getenv("ECLIPSE_HOME"); //$NON-NLS-1$
-        String app = homedir + "/.." + DOCGEN_DIR + XSLTPROC_EXE;
+        String homedir = System.getenv("BPHOMEDIR"); //$NON-NLS-1$
+        String app = homedir + DOCGEN_DIR + XSLTPROC_EXE;
+        String includepath = "--path " + homedir + "/.." + XHTMLFILES;
         String xslfile = DOCGEN_XSL;
         String xmlfile = DOC_XML; 
         String htmlfile = DOC_HTML;
@@ -434,7 +436,7 @@ public class Generator extends Task {
             }
         }
         
-        ProcessBuilder pb = new ProcessBuilder(app, xslfile, xmlfile); 
+        ProcessBuilder pb = new ProcessBuilder(app, includepath, xslfile, xmlfile); 
         pb.directory(new File(workingDir));
         pb.redirectErrorStream(true);
         Process process = pb.start();


### PR DESCRIPTION
More changes to simplify post-install.
- Don't call sed or update_text to modify files
- Don't show release notes during installer
- Don't modify the PATH in the launcher for docbook
- Fix variable used to access docgen