### PR TITLE
job #7600 #7610 #7632 - Remove invalid file spec that tries to look for

### DIFF
--- a/src/org.xtuml.bp.als/generate.xml
+++ b/src/org.xtuml.bp.als/generate.xml
@@ -212,18 +212,12 @@
           <fileset dir="${plugins-home}/plugins" casesensitive="yes">
             <include name="**/antlr.jar" />
           </fileset>
-          <fileset dir="${plugins-home}/dropins" casesensitive="yes">
-            <include name="**/antlr.jar" />
-          </fileset>
         </classpath>
     </antlr>
 
     <antlr target="../org.xtuml.bp.als.oal/src/org/xtuml/bp/als/oal/oal_lex.g" >
         <classpath>
           <fileset dir="${plugins-home}/plugins" casesensitive="yes">
-            <include name="**/antlr.jar" />
-          </fileset>
-          <fileset dir="${plugins-home}/dropins" casesensitive="yes">
             <include name="**/antlr.jar" />
           </fileset>
         </classpath>


### PR DESCRIPTION
antlr plugins under dropins.  They are just part of the eclipse base
now.