### PR TITLE
job #8485

### DIFF
--- a/src/org.xtuml.bp.core/src/org/xtuml/bp/core/common/PersistableModelComponent.java
+++ b/src/org.xtuml.bp.core/src/org/xtuml/bp/core/common/PersistableModelComponent.java
@@ -487,7 +487,7 @@ public class PersistableModelComponent implements Comparable {
     }
     
     public boolean isLoaded() {
-        return !(componentRootME == null || componentRootME.isProxy());
+        return !(componentRootME == null);
     }
     
     public boolean isOrphaned(){

--- a/src/org.xtuml.bp.core/src/org/xtuml/bp/core/common/PersistenceManager.java
+++ b/src/org.xtuml.bp.core/src/org/xtuml/bp/core/common/PersistenceManager.java
@@ -514,6 +514,10 @@ public class PersistenceManager {
 		if (handler.requirements != null && !handler.requirements.isEmpty()) {
 			handler.performUpgrade();
 		}
+		// Fully load all models
+		for (int i = 0; i < roots.length; ++i) {
+			roots[i].loadComponentAndChildren(new NullProgressMonitor());
+		}
         initializing = false;
         
     }


### PR DESCRIPTION
I made the change to force all models to be loaded when the workspace is
first opened. I did this by adding a call to loadComponentAndChildren to
PersistenceManager.java::initialize after the import has completed and
modifying PersisteableModelComponent.java::isLoaded() to no longer
consider a loaded proxy as having loaded the PMC.