### PR TITLE
job #8472 imported interface reference drawing fix

### DIFF
--- a/src/org.xtuml.bp.core/models/org.xtuml.bp.core/ooaofooa/Component/Component Library/Component Reference/Component Reference.xtuml
+++ b/src/org.xtuml.bp.core/models/org.xtuml.bp.core/ooaofooa/Component/Component Library/Component Reference/Component Reference.xtuml
@@ -860,13 +860,10 @@ for each importedRef in importedRefs
       end if;    
     end if;
     if(not_empty provision)
-      select one provisionPkg related by provision->C_IR[R4009]->C_PO[R4016]->C_C[R4010]->PE_PE[R8001]->EP_PKG[R8000];
-      if (not_empty provisionPkg and outerPkg.Package_ID == provisionPkg.Package_ID)
         count = count + 1;
         if (count == param.index)
           return provision.Provision_Id;
         end if;
-      end if;
     end if;
 end for;
 return id;',
@@ -917,13 +914,10 @@ for each importedRef in importedRefs
       end if;    
     end if;
     if(not_empty requirement)
-      select one rPkg related by requirement->C_IR[R4009]->C_PO[R4016]->C_C[R4010]->PE_PE[R8001]->EP_PKG[R8000];
-      if (not_empty rPkg and outerPkg.Package_ID == rPkg.Package_ID)
         count = count + 1;
         if (count == param.index)
           return requirement.Requirement_Id;
         end if;
-      end if;
     end if;
 end for;
 return id;',

--- a/src/org.xtuml.bp.ui.canvas/models/org.xtuml.bp.ui.canvas/ooaofgraphics/Graphical Data/Auto Reconciliation Specification/Auto Reconciliation Specification.xtuml
+++ b/src/org.xtuml.bp.ui.canvas/models/org.xtuml.bp.ui.canvas/ooaofgraphics/Graphical Data/Auto Reconciliation Specification/Auto Reconciliation Specification.xtuml
@@ -16,7 +16,7 @@ INSERT INTO O_TFR
 	'',
 	"ba5eda7a-def5-0000-0000-000000000005",
 	1,
-	'if (param.connectorID != OS::NULL_UNIQUE_ID())
+	'if (param.connectorID == OS::NULL_UNIQUE_ID())
   return OS::NULL_UNIQUE_ID();
 end if;
 select one spec related by self->GD_ES[R30];


### PR DESCRIPTION
job #8472 this commit removes the inner/outer package check in CL_IC.getImportedProvisionProvisionId and CL_IC.getImportedRequirementRequirementID. In this situation, the inner/outer check is not appropriate. Issue #8535 has been raised to analyze other places where this is or is not appropriate. This commit also includes a small logic fix in GD_ARS.findConnector