### PR TITLE
job #8349 Edited the default preference setting for the new preference

### DIFF
--- a/src/org.xtuml.bp.core/src/org/xtuml/bp/core/common/BridgePointPreferencesStore.java
+++ b/src/org.xtuml.bp.core/src/org/xtuml/bp/core/common/BridgePointPreferencesStore.java
@@ -243,7 +243,7 @@ public class BridgePointPreferencesStore implements IPreferenceModelStore {
         prefs.allowIntToRealPromotion = MessageDialogWithToggle.ALWAYS;
         prefs.allowRealToIntCoercion = MessageDialogWithToggle.ALWAYS;
         prefs.allowImplicitComponentAddressing = false;
-        prefs.enableParseOnActivtyEdits = false;
+        prefs.enableParseOnActivtyEdits = true;
         prefs.allowOperationsInWhere = false;
         prefs.allowInterfaceNameInICMessage = false;
         prefs.enableErrorForEmptySynchronousMessage = true;


### PR DESCRIPTION
"Parse while editing OAL activities" to restore the default parse on
edit behavior to match the prior version of BridgePoint. Parsing will
occur during editing by default. This preference can be changed when
desired under xtUML > Action Language preferences. 

This is a 1 line change to a preference, there is no additional documentation for this task.