### PR TITLE
job #8582 In isolating this problem I added a read and dispatch look at

### DIFF
--- a/src/org.xtuml.bp.ui.text.test/src/org/xtuml/bp/ui/text/test/i673Tests/rename/I673RenameObjectsAndTestDescriptionEditors.java
+++ b/src/org.xtuml.bp.ui.text.test/src/org/xtuml/bp/ui/text/test/i673Tests/rename/I673RenameObjectsAndTestDescriptionEditors.java
@@ -25,6 +25,7 @@ package org.xtuml.bp.ui.text.test.i673Tests.rename;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.jface.viewers.TreeViewer;
 import org.eclipse.jface.wizard.WizardDialog;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IEditorPart;
@@ -65,6 +66,7 @@ import org.xtuml.bp.test.common.OrderedRunner;
 import org.xtuml.bp.test.common.TestingUtilities;
 import org.xtuml.bp.test.common.TextEditorUtils;
 import org.xtuml.bp.ui.canvas.Cl_c;
+import org.xtuml.bp.ui.explorer.ExplorerView;
 import org.xtuml.bp.ui.text.description.DescriptionEditor;
 import org.xtuml.bp.ui.text.test.UITextTest;
 import org.xtuml.bp.ui.text.test.description.DescriptionEditorInteraction;
@@ -99,7 +101,12 @@ public class I673RenameObjectsAndTestDescriptionEditors extends UITextTest {
 			loadProject(testModelName);
 			while( d.readAndDispatch() ){}			
 			TestingUtilities.allowJobCompletion();
-
+			
+			ExplorerView view = (ExplorerView) PlatformUI.getWorkbench()
+					.getActiveWorkbenchWindow().getActivePage().showView(
+							"org.xtuml.bp.ui.explorer.ExplorerView");
+			view.getTreeViewer().expandToLevel(m_sys, TreeViewer.ALL_LEVELS);			
+			
 			isFirstTime=false;
 		}
 	}
@@ -129,6 +136,7 @@ public class I673RenameObjectsAndTestDescriptionEditors extends UITextTest {
 	
 	@Test
 	public void testRenamePackage(){
+
 		ClassQueryInterface_c pkgQuery = new ClassQueryInterface_c(){
             public boolean evaluate(Object candidate){
                 return (((Package_c)candidate).getName().equals(testModelName));
@@ -186,7 +194,7 @@ public class I673RenameObjectsAndTestDescriptionEditors extends UITextTest {
 	public void testRenameAssociation(){
 		Association_c assoc = Association_c.AssociationInstance(modelRoot);
 		assertNotNull(assoc);
-		
+
 		//Get attribute reference in class is effected by Association name so create instance of that as well
 		AttributeReferenceInClass_c ref = AttributeReferenceInClass_c.getOneO_REFOnR111(ReferringClassInAssoc_c.getOneR_RGOOnR203(ClassInAssociation_c.getOneR_OIROnR201(assoc)));
 		assertNotNull(ref);


### PR DESCRIPTION
the point of failure which is what allowed me to see that attributes
were missing from the test model. Of course at that point I stepped to
find where the attributes were being lost. What I ended up observing was
that if, during the read and dispatch loops I expanded the ME tree to
watch the model element with the problem, the problem would not happen.
I tested to assure I could not reproduce this problem manually. I then
observed that by adding ME tree expansion to the initial setup of the
test the problem does not happen. I believe this problem is caused by
the loading and unloading of the model that we do as part of this test
suite. The change made fixes the test and I am not investigating
further.

The test model used for this test is models/testDescrip1 and the class
that lost all attributes was testDescrip1 > Test Subsystem > Test Class