### PR TITLE
job:  #8612  compare test arc typo

### DIFF
--- a/src/org.xtuml.bp.model.compare.test/arc/generate_metamodel_compare_test.arc
+++ b/src/org.xtuml.bp.model.compare.test/arc/generate_metamodel_compare_test.arc
@@ -77,7 +77,7 @@ public class ModelComparisonTests extends BaseTest {
 
 	private static String modifyString = "_modified";
 	
-		@Override
+	@Override
 	public void initialSetup() throws CoreException, IOException {
 		// load test model 
 		WorkspaceUtil.setAutobuilding(false);


### PR DESCRIPTION
An extra indenting tab was before the Override directive.