### PR TITLE
job #8703 - Close RandomAccessFile in BPClassLoader

### DIFF
--- a/src/org.xtuml.bp.core/src/org/xtuml/bp/core/util/BPClassLoader.java
+++ b/src/org.xtuml.bp.core/src/org/xtuml/bp/core/util/BPClassLoader.java
@@ -102,10 +102,10 @@ public class BPClassLoader extends ClassLoader {
 				    return definitions.get(file.toString());
 				}
 			    byte[] classbytes;
-			    try {
-				  RandomAccessFile raf = new RandomAccessFile(file, "r");
+			    try (RandomAccessFile raf = new RandomAccessFile(file, "r")) {
 				  classbytes = new byte[(int) raf.length()];
 				  raf.read(classbytes);
+				  // raf is auto closed
 			    } catch (IOException e) {
 				  return null;
 			    }


### PR DESCRIPTION
This fixes the bug described in issue #8703.

Solved by using try with resources introduced with Java 7, which will close the stream whether the try statement runs normally or catches an exception.