### PR TITLE
Update 8458_Model_Element_Move_Tests.dnt.md

### DIFF
--- a/doc-bridgepoint/notes/8458_model_element_move_tests/8458_Model_Element_Move_Tests.dnt.md
+++ b/doc-bridgepoint/notes/8458_model_element_move_tests/8458_Model_Element_Move_Tests.dnt.md
@@ -82,8 +82,7 @@ VisibleInterface.
 >* Perform undo.  
 
 7.3 Use Case 4.3  
-7.3.1. ComponentMovePass1 in Source package FailureCasesComponentPackage is 
-moved to Destination package.  
+7.3.1. ComponentMovePass1 in Source package is moved to Destination package.  
 >* Result is successful move with no option menu shown for list of lost 
 visibility items.  
 >* Perform undo.  


### PR DESCRIPTION
Error in test case 7.3.1 is an invalid reference in the model.