### PR TITLE
Fix issue #8813 - Assign Signal visible for Instance State Machines 

### DIFF
--- a/src/org.xtuml.bp.core.test/src/org/xtuml/bp/core/test/ComponentContextMenuTests2.java
+++ b/src/org.xtuml.bp.core.test/src/org/xtuml/bp/core/test/ComponentContextMenuTests2.java
@@ -27,6 +27,7 @@ import org.xtuml.bp.core.Component_c;
 import org.xtuml.bp.core.CorePlugin;
 import org.xtuml.bp.core.Delegation_c;
 import org.xtuml.bp.core.ExecutableProperty_c;
+import org.xtuml.bp.core.InstanceStateMachine_c;
 import org.xtuml.bp.core.InterfaceReference_c;
 import org.xtuml.bp.core.InterfaceSignal_c;
 import org.xtuml.bp.core.Interface_c;
@@ -153,6 +154,47 @@ public class ComponentContextMenuTests2 extends BaseTest {
 		}
 		wd.close();
 	}
+
+	@Test
+	public void testContextMenuAssignSignalOnSM_TXN() {
+		ModelClass_c csm_cut = ModelClass_c.ModelClassInstance(modelRoot, new ClassQueryInterface_c() {
+			public boolean evaluate(Object candidate) {
+				return ((ModelClass_c) candidate).getName().equals("Class_With_CSM");
+			}
+
+		});
+
+		ModelClass_c ism_cut = ModelClass_c.ModelClassInstance(modelRoot, new ClassQueryInterface_c() {
+			public boolean evaluate(Object candidate) {
+				return ((ModelClass_c) candidate).getName().equals("Class_With_ISM");
+			}
+
+		});
+
+		assertNotNull(csm_cut);
+		assertNotNull(ism_cut);
+		Transition_c csm_trans_obj = Transition_c
+				.getOneSM_TXNOnR505(StateMachine_c.getManySM_SMsOnR517(ClassStateMachine_c.getManySM_ASMsOnR519(csm_cut)));
+		Transition_c ism_trans_obj = Transition_c
+				.getOneSM_TXNOnR505(StateMachine_c.getManySM_SMsOnR517(InstanceStateMachine_c.getManySM_ISMsOnR518(ism_cut)));
+
+		//check available
+		checkContextMenuAssignSignalActionOnSM_TXN(csm_trans_obj, true);
+		checkContextMenuAssignSignalActionOnSM_TXN(ism_trans_obj, false);
+	}
+
+	private void checkContextMenuAssignSignalActionOnSM_TXN(Transition_c obj, boolean expected) {
+		assertNotNull(obj);
+
+		editor = UITestingUtilities.addElementToGraphicalSelection(obj);
+
+		// get the menu from the SWT Canvas
+		Menu menu = editor.getCanvas().getMenu();
+
+		// check the status of the action
+		assertEquals(expected, UITestingUtilities.checkItemStatusInContextMenu(menu, "Assign Signal", "", m_readonly));
+	}
+
 	@Test
 	public void testContextMenuAssignSignalActionOnSM_TXNCantUseSameTwice() {
 		performContextMenuAssignSignalActionOnSM_TXNCantUseSameTwice("owner_state", "Port_CMT");

--- a/src/org.xtuml.bp.core/models/org.xtuml.bp.core/ooaofooa/State Machine/Transition/Transition.xtuml
+++ b/src/org.xtuml.bp.core/models/org.xtuml.bp.core/ooaofooa/State Machine/Transition/Transition.xtuml
@@ -212,15 +212,11 @@ INSERT INTO O_TFR
 	1,
 	'if (param.name == "event" )
   
-  if (param.value == "exists spec pkg" ) or (param.value == "exists generic pkg" )
+  if (param.value == "exists generic pkg" )
   
     select one cls related by self->SM_SM[R505]->SM_ASM[R517]->O_OBJ[R519];
     if (empty cls)
       select one cls related by self->SM_SM[R505]->SM_ISM[R517]->O_OBJ[R518];
-    end if;
-
-    if (param.value == "exists spec pkg")
-      return false;
     end if;
       
     // might want to enforce data set consistency here
@@ -314,11 +310,11 @@ INSERT INTO O_TFR
     return not_empty levt;
   end if;
 elif param.name == "signal"
-  if (param.value == "exists spec pkg") or (param.value == "exists generic pkg") 
+  if (param.value == "exists generic pkg") 
     select one cls related by self->SM_SM[R505]->SM_ASM[R517]->O_OBJ[R519];
-    if (empty cls)
-      select one cls related by self->SM_SM[R505]->SM_ISM[R517]->O_OBJ[R518];
-    end if;
+    //if (empty cls)
+    //  select one cls related by self->SM_SM[R505]->SM_ISM[R517]->O_OBJ[R518];
+    //end if;
     select one packageableElem related by cls->PE_PE[R8001];
     select one package related by packageableElem->EP_PKG[R8000];
     // Currently component will always be null, but this may change
@@ -327,13 +323,9 @@ elif param.name == "signal"
       compId = package.getContainingComponentId();
       select any component from instances of C_C where (selected.Id == compId);
     end if;
-    isInGenericPackage = not_empty package or not_empty component;
     // if there is no containing component, then this action should be
     // filtered
     if(empty component)
-      return false;
-    end if;
-    if ((param.value == "exists spec pkg"))
       return false;
     end if;
       

--- a/src/org.xtuml.bp.core/models/org.xtuml.bp.core/ooaofooa/State Machine/Transition/Transition.xtuml
+++ b/src/org.xtuml.bp.core/models/org.xtuml.bp.core/ooaofooa/State Machine/Transition/Transition.xtuml
@@ -312,9 +312,9 @@ INSERT INTO O_TFR
 elif param.name == "signal"
   if (param.value == "exists generic pkg") 
     select one cls related by self->SM_SM[R505]->SM_ASM[R517]->O_OBJ[R519];
-    //if (empty cls)
-    //  select one cls related by self->SM_SM[R505]->SM_ISM[R517]->O_OBJ[R518];
-    //end if;
+    if (empty cls)
+      return false;
+    end if;
     select one packageableElem related by cls->PE_PE[R8001];
     select one package related by packageableElem->EP_PKG[R8000];
     // Currently component will always be null, but this may change


### PR DESCRIPTION
Updated the filtering for "Assign Signal" operation so that it is not shown for Instance State Machines.

This pull request requires xtuml/models#87 for test to pass.