### PR TITLE
job #8954 - removed ".exe" on the xtumlmc_build constant. Tested and

### DIFF
--- a/src/org.xtuml.bp.x2m/src/org/xtuml/bp/x2m/generator/Generator.java
+++ b/src/org.xtuml.bp.x2m/src/org/xtuml/bp/x2m/generator/Generator.java
@@ -48,7 +48,7 @@ public class Generator extends Task {
     
     public static final String X2M_DIR = "/tools/mc/bin/";
     public static final String X2M_CMD = "xtuml2masl";
-    public static final String X2M_EXE = "xtumlmc_build.exe";
+    public static final String X2M_EXE = "xtumlmc_build";
     public static final String MASL_DIR = "/masl/";
     public static final String CODE_GEN_DIR = "/gen/code_generation/";
     public static final String LOGFILE = "export.log";


### PR DESCRIPTION
verified I could now run "Export MASL domain".  Literally a 4-character
removal.  No other documentation needed.