### PR TITLE
#8970 Revalidate mod files when implementation files change

### DIFF
--- a/src/org.xtuml.bp.xtext.masl.parent/org.xtuml.bp.xtext.masl/src/org/xtuml/bp/xtext/masl/scoping/MASLResourceDescriptionStrategy.xtend
+++ b/src/org.xtuml.bp.xtext.masl.parent/org.xtuml.bp.xtext.masl/src/org/xtuml/bp/xtext/masl/scoping/MASLResourceDescriptionStrategy.xtend
@@ -1,44 +1,87 @@
 package org.xtuml.bp.xtext.masl.scoping
 
+import com.google.common.base.Charsets
+import com.google.common.hash.Hashing
+import com.google.inject.Inject
 import org.eclipse.emf.ecore.EObject
+import org.eclipse.xtext.naming.QualifiedName
+import org.eclipse.xtext.nodemodel.util.NodeModelUtils
+import org.eclipse.xtext.resource.EObjectDescription
 import org.eclipse.xtext.resource.IEObjectDescription
 import org.eclipse.xtext.resource.impl.DefaultResourceDescriptionStrategy
 import org.eclipse.xtext.util.IAcceptor
+import org.xtuml.bp.xtext.masl.MASLExtensions
 import org.xtuml.bp.xtext.masl.masl.structure.DomainDefinition
 import org.xtuml.bp.xtext.masl.masl.structure.MaslModel
-import org.xtuml.bp.xtext.masl.masl.types.BuiltinTypeDeclaration
 import org.xtuml.bp.xtext.masl.masl.structure.ObjectDefinition
-import org.xtuml.bp.xtext.masl.masl.types.TypeDeclaration
-import org.xtuml.bp.xtext.masl.masl.types.EnumerationTypeDefinition
-import org.eclipse.xtext.resource.EObjectDescription
-import org.xtuml.bp.xtext.masl.MASLExtensions
-import com.google.inject.Inject
-import org.eclipse.xtext.naming.QualifiedName
 import org.xtuml.bp.xtext.masl.masl.structure.TerminatorDefinition
+import org.xtuml.bp.xtext.masl.masl.types.BuiltinTypeDeclaration
+import org.xtuml.bp.xtext.masl.masl.types.EnumerationTypeDefinition
+import org.xtuml.bp.xtext.masl.masl.types.TypeDeclaration
+import org.apache.log4j.Logger
 
 class MASLResourceDescriptionStrategy extends DefaultResourceDescriptionStrategy {
-	
+
+	static val String HASH_USER_DATA_KEY = 'HASH'
+
+	static val LOG = Logger.getLogger(MASLResourceDescriptionStrategy)
+
 	@Inject extension MASLExtensions
-	
+
 	override createEObjectDescriptions(EObject eObject, IAcceptor<IEObjectDescription> acceptor) {
 		switch eObject {
 			BuiltinTypeDeclaration:
-				if(eObject.anonymous)
+				if (eObject.anonymous)
 					return false
 			TypeDeclaration: {
-				val definition = eObject.definition			
+				val definition = eObject.definition
 				if (definition instanceof EnumerationTypeDefinition) {
-					definition.enumerators.forEach[
+					definition.enumerators.forEach [
 						acceptor.accept(EObjectDescription.create(QualifiedName.create(domainName, name), it))
-					]		
+					]
 				}
 			}
 		}
-		super.createEObjectDescriptions(eObject, acceptor)
+		doCreateEObjectDescriptions(eObject, acceptor)
 		return eObject instanceof ObjectDefinition 
 			|| eObject instanceof DomainDefinition 
-			|| eObject instanceof MaslModel
+			|| eObject instanceof MaslModel 
 			|| eObject instanceof TerminatorDefinition
 	}
-	
+
+	private def doCreateEObjectDescriptions(EObject eObject, IAcceptor<IEObjectDescription> acceptor) {
+		try {
+			val qualifiedName = qualifiedNameProvider.getFullyQualifiedName(eObject)
+			if (qualifiedName !== null) {
+				val hash = eObject.hash
+				if(hash != null) 
+					acceptor.accept(EObjectDescription.create(qualifiedName, eObject, #{HASH_USER_DATA_KEY->hash}))
+				else 
+					acceptor.accept(EObjectDescription.create(qualifiedName, eObject))
+			}
+		} catch (Exception exc) {
+			LOG.error(exc.getMessage(), exc)
+		}
+		return true
+	}
+
+	/**
+	 * We have to make sure the downstream dependencies get rebuilt when a signature changes. 
+	 * This is why we add a hash of the signature to the eobject description. 
+	 * But we are not allowed to resolve anything in the signatures during indexing.
+	 * So we use a rough approach hashing the concrete syntax without comments and whitespaces.
+	 */
+	private def hash(EObject element) {
+		if (element === null)
+			return null
+		val node = NodeModelUtils.findActualNodeFor(element)
+		if (node === null)
+			return null
+		val hasher = Hashing.md5.newHasher
+		node?.leafNodes.filter[!hidden].forEach [
+			hasher.putString(text + " ", Charsets.UTF_8)
+		]
+		hasher.hash.toString
+	}
+
 }

--- a/src/org.xtuml.bp.xtext.masl.parent/org.xtuml.bp.xtext.masl/src/org/xtuml/bp/xtext/masl/scoping/MaslResourceDescriptionManager.xtend
+++ b/src/org.xtuml.bp.xtext.masl.parent/org.xtuml.bp.xtext.masl/src/org/xtuml/bp/xtext/masl/scoping/MaslResourceDescriptionManager.xtend
@@ -12,10 +12,12 @@ class MaslResourceDescriptionManager extends DefaultResourceDescriptionManager i
 		// Rebuild dependent resources on all changes in the resource.
 		// This is necessary, as we're linking against elements which are not 
 		// indexed, e.g. action signatures.  
-		true
+		super.hasChanges(delta, candidate)
 	}
 	
 	override isAffectedByAny(Collection<Delta> deltas, IResourceDescription candidate, IResourceDescriptions context) throws IllegalArgumentException {
+		if(candidate.URI.fileExtension == 'mod')
+			return true
 		isAffected(deltas, candidate, context)
 	}
 	


### PR DESCRIPTION
When the user edits the implementation of an activity, e.g. a service, and saves the editor, the respective mod file has to be re-validated as well, as the warnings on missing implementations may have to be updated. As usually everything depends on some mod file, the affection calculation had to be fine-tuned in order to avoid entering a cycle where each change in any file triggers the re-validation of all files in the workspace.