### PR TITLE
job #9281 pessimistic locking move dialog

### DIFF
--- a/doc-bridgepoint/notes/8458_model_element_move_tests/8458_Model_Element_Move_Tests.dnt.md
+++ b/doc-bridgepoint/notes/8458_model_element_move_tests/8458_Model_Element_Move_Tests.dnt.md
@@ -239,7 +239,7 @@ related across R3 in Source package is moved to Destination package.
       * Imported class reference to ModelElementMoveTests::Source::FailureCasesComponent::FailureCasesComponentPackage::InvisibleImports::InvisibleImportClass to unassigned
   * Perform undo.   
  
-7.13 Pessimistic Locking Test - Assure RGOs are not checked out. (Uses test model [2.6](#2.6))  
+7.13 Pessimistic Locking Test - Assure RGOs are not checked-out/dirtied by the move operation. (Uses test model [2.6](#2.6))  
   * 1. Select BOTH mybasetype and mysubtype in Model Explorer from package name impl and cut
   * 2. Paste into decl2  
   * 3. Results 

--- a/doc-bridgepoint/notes/8458_model_element_move_tests/8458_Model_Element_Move_Tests.dnt.md
+++ b/doc-bridgepoint/notes/8458_model_element_move_tests/8458_Model_Element_Move_Tests.dnt.md
@@ -240,11 +240,13 @@ related across R3 in Source package is moved to Destination package.
   * Perform undo.   
  
 7.13 Pessimistic Locking Test - Assure RGOs are not checked-out/dirtied by the move operation. (Uses test model [2.6](#2.6))  
-  * 1. Select BOTH mybasetype and mysubtype in Model Explorer from package name impl and cut
+  * 1. In Model Explorer
+    * select BOTH mybasetype and mysubtype from package name impl
+    * cut
   * 2. Paste into decl2  
   * 3. Results 
-  * 3.1 no dialog appears
-  * 3.2 the only packages marked dirty are impl and dest2
+    * 3.1 no dialog appears
+    * 3.2 the only packages marked dirty are impl and dest2
   * 4. select package named Functions in Model Explorer, RC, BridgePoint Utilities > Load and Persist
   * 5. Result - Functions is marked dirty
   * 6. Compare package Functions with the lastest from head

--- a/doc-bridgepoint/notes/8458_model_element_move_tests/8458_Model_Element_Move_Tests.dnt.md
+++ b/doc-bridgepoint/notes/8458_model_element_move_tests/8458_Model_Element_Move_Tests.dnt.md
@@ -239,9 +239,18 @@ related across R3 in Source package is moved to Destination package.
       * Imported class reference to ModelElementMoveTests::Source::FailureCasesComponent::FailureCasesComponentPackage::InvisibleImports::InvisibleImportClass to unassigned
   * Perform undo.   
  
-7.13 Obsolete - Pessimistic Locking Test - test checkout of RGOs with a Pessimistic locking RCS.   
-  * This test is obsolete with the fix to issue 7877 because we no longer force persistance of RGOs.
-  
+7.13 Pessimistic Locking Test - Assure RGOs are not checked out. (Uses test model [2.6](#2.6))  
+  * 1. Select BOTH mybasetype and mysubtype in Model Explorer from package name impl and cut
+  * 2. Paste into decl2  
+  * 3. Results 
+  * 3.1 no dialog appears
+  * 3.2 the only packages marked dirty are impl and dest2
+  * 4. select package named Functions in Model Explorer, RC, BridgePoint Utilities > Load and Persist
+  * 5. Result - Functions is marked dirty
+  * 6. Compare package Functions with the lastest from head
+  * 7. Result - You should see that the proxy was modified to point to the moved datatype
+
+
 7.14 Moving a Package (use 2.7)
   * 1.    Cut pkg1_1
   * 2.    Paste into pkg2


### PR DESCRIPTION
This change simply adds a new test to the model element move test plan to assure RGOs (proxies) are not updated on move.