### PR TITLE
Update 8458_Model_Element_Move_Tests.dnt.md

### DIFF
--- a/doc-bridgepoint/notes/8458_model_element_move_tests/8458_Model_Element_Move_Tests.dnt.md
+++ b/doc-bridgepoint/notes/8458_model_element_move_tests/8458_Model_Element_Move_Tests.dnt.md
@@ -363,7 +363,7 @@ related across R3 in Source package is moved to Destination package.
   * 4. Paste TestInterface to impl2
   * 5. Downgrade dialog indicates downgrade on TestInterface operations and signals use of UDT (the dest) since they lost visibility to type mysubtype under p1/impl
   * 6. Proceed with the move
-  * 7. p2/impl2 contains "Unassigned Imported Component", the graphics for the p2/impl2 canvas are correct.
+  * 7. p2/impl2 canvas is empty.
 
 7.27 Move imported class causing downgrade in destination (Uses test model [2.6](#2.6))
   * 1. Open the canvas for movetest/p1/impl/refs
@@ -375,7 +375,7 @@ related across R3 in Source package is moved to Destination package.
   * 7. p2/impl2 canvas contains "Unassigned Imported Class", the graphics are correct.
   * 8. Restart BridgePoint
   * 9. Open the p1/impl/refs canvas, the imported class is gone.
-  * 10. Open the p2/impl2 canvas, the Unassigned Imported Class shows
+  * 10. The p2/impl2 canvas is empty.
 
 7.28 Move package causing downgrade in destination (Uses test model [2.6](#2.6))
   * 1. Open the canvas for movetest/p1/impl
@@ -415,7 +415,7 @@ related across R3 in Source package is moved to Destination package.
   * 4. paste the selection into the package named private
   * 5. The downgrade dialog should report that the component reference will be downgraded, select ok
   * 6. Result 1 - The satisfaction_test component diagram no longer shows compp-1 (it has been moved to "private".
-  * 7. Result 2 - The component reference to comp1 is present in satisfaction_test, but the satisfaction is no longer present.
+  * 7. Result 2 - The component reference to comp1 and the satisfaction are no longer present.
   * 8. select undo
   * 9. The mode is restored
   * 10. select redo


### PR DESCRIPTION
Fix tests to remove result of an unassigned element placed on the target canvas.