### PR TITLE
9675 owner info

### DIFF
--- a/releng/org.xtuml.bp.mctools/feature.xml
+++ b/releng/org.xtuml.bp.mctools/feature.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <feature
       id="org.xtuml.bp.mctools"
-      label="X86"
+      label="BridgePoint Model Compiler Tools"
       version="1.0.0.qualifier">
 
    <description>

--- a/src/org.xtuml.bp.core.editors/META-INF/MANIFEST.MF
+++ b/src/org.xtuml.bp.core.editors/META-INF/MANIFEST.MF
@@ -27,3 +27,4 @@ Export-Package: org.xtuml.bp.core.editors,
  org.xtuml.bp.core.editors.editing,
  org.xtuml.bp.core.editors.providers
 Bundle-ClassPath: editors.jar
+Bundle-Vendor: xtUML.org

--- a/src/org.xtuml.bp.xtext.masl.parent/org.xtuml.bp.xtext.generator/META-INF/MANIFEST.MF
+++ b/src/org.xtuml.bp.xtext.masl.parent/org.xtuml.bp.xtext.generator/META-INF/MANIFEST.MF
@@ -2,8 +2,8 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Custom Lexer Generator Fragment
 Bundle-SymbolicName: org.xtuml.bp.xtext.generator
-Bundle-Version: 1.0.0.qualifier
-Bundle-Vendor: OneFact
+Bundle-Version: 6.6.1.qualifier
+Bundle-Vendor: xtUML.org
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: com.google.guava,
  org.eclipse.xtext.xbase.lib,

--- a/src/org.xtuml.bp.xtext.masl.parent/org.xtuml.bp.xtext.generator/pom.xml
+++ b/src/org.xtuml.bp.xtext.masl.parent/org.xtuml.bp.xtext.generator/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.xtuml.bp.xtext.masl</groupId>
 		<artifactId>org.xtuml.bp.xtext.masl.parent</artifactId>
-		<version>1.0.0-SNAPSHOT</version>
+		<version>6.6.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>org.xtuml.bp.xtext.generator</artifactId>
 	<packaging>eclipse-plugin</packaging>

--- a/src/org.xtuml.bp.xtext.masl.parent/org.xtuml.bp.xtext.masl.feature/feature.xml
+++ b/src/org.xtuml.bp.xtext.masl.parent/org.xtuml.bp.xtext.masl.feature/feature.xml
@@ -2,19 +2,25 @@
 <feature
       id="org.xtuml.bp.xtext.masl.feature"
       label="MASL Editor Feature"
-      version="1.0.0.qualifier"
-      provider-name="OneFact Inc.">
+      version="6.6.1.qualifier"
+      provider-name="xtUML.org">
 
-   <description url="http://www.example.com/description">
-      [Enter Feature Description here.]
-   </description>
-
-   <copyright url="http://www.example.com/copyright">
-      [Enter Copyright Description here.]
+   <copyright>
+      © Copyright 2016-2017 xtUML.org.  All rights reserved.
    </copyright>
 
-   <license url="http://www.example.com/license">
-      [Enter License Description here.]
+   <license url="license.html">
+      Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not 
+use this file except in compliance with the License.  You may obtain a copy 
+of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software 
+distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT 
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   See the 
+License for the specific language governing permissions and limitations under
+the License.
    </license>
 
    <plugin

--- a/src/org.xtuml.bp.xtext.masl.parent/org.xtuml.bp.xtext.masl.feature/pom.xml
+++ b/src/org.xtuml.bp.xtext.masl.parent/org.xtuml.bp.xtext.masl.feature/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.xtuml.bp.xtext.masl</groupId>
 		<artifactId>org.xtuml.bp.xtext.masl.parent</artifactId>
-		<version>1.0.0-SNAPSHOT</version>
+		<version>6.6.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>org.xtuml.bp.xtext.masl.feature</artifactId>
 	<packaging>eclipse-feature</packaging>

--- a/src/org.xtuml.bp.xtext.masl.parent/org.xtuml.bp.xtext.masl.ide/META-INF/MANIFEST.MF
+++ b/src/org.xtuml.bp.xtext.masl.parent/org.xtuml.bp.xtext.masl.ide/META-INF/MANIFEST.MF
@@ -1,8 +1,8 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: MASL Xtext generic IDE support
-Bundle-Vendor: OneFact
-Bundle-Version: 1.0.0.qualifier
+Bundle-Vendor: xtUML.org
+Bundle-Version: 6.6.1.qualifier
 Bundle-SymbolicName: org.xtuml.bp.xtext.masl.ide; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.xtuml.bp.xtext.masl,

--- a/src/org.xtuml.bp.xtext.masl.parent/org.xtuml.bp.xtext.masl.ide/pom.xml
+++ b/src/org.xtuml.bp.xtext.masl.parent/org.xtuml.bp.xtext.masl.ide/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.xtuml.bp.xtext.masl</groupId>
 		<artifactId>org.xtuml.bp.xtext.masl.parent</artifactId>
-		<version>1.0.0-SNAPSHOT</version>
+		<version>6.6.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>org.xtuml.bp.xtext.masl.ide</artifactId>
 	<packaging>eclipse-plugin</packaging>

--- a/src/org.xtuml.bp.xtext.masl.parent/org.xtuml.bp.xtext.masl.target/pom.xml
+++ b/src/org.xtuml.bp.xtext.masl.parent/org.xtuml.bp.xtext.masl.target/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.xtuml.bp.xtext.masl</groupId>
 		<artifactId>org.xtuml.bp.xtext.masl.parent</artifactId>
-		<version>1.0.0-SNAPSHOT</version>
+		<version>6.6.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>org.xtuml.bp.xtext.masl.target</artifactId>
 	<packaging>eclipse-target-definition</packaging>

--- a/src/org.xtuml.bp.xtext.masl.parent/org.xtuml.bp.xtext.masl.tests/META-INF/MANIFEST.MF
+++ b/src/org.xtuml.bp.xtext.masl.parent/org.xtuml.bp.xtext.masl.tests/META-INF/MANIFEST.MF
@@ -1,8 +1,8 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: MASL Xtext tests
-Bundle-Vendor: OneFacr
-Bundle-Version: 1.0.0.qualifier
+Bundle-Vendor: xtUML.org
+Bundle-Version: 6.6.1.qualifier
 Bundle-SymbolicName: org.xtuml.bp.xtext.masl.tests; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.xtuml.bp.xtext.masl,

--- a/src/org.xtuml.bp.xtext.masl.parent/org.xtuml.bp.xtext.masl.tests/pom.xml
+++ b/src/org.xtuml.bp.xtext.masl.parent/org.xtuml.bp.xtext.masl.tests/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.xtuml.bp.xtext.masl</groupId>
 		<artifactId>org.xtuml.bp.xtext.masl.parent</artifactId>
-		<version>1.0.0-SNAPSHOT</version>
+		<version>6.6.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>org.xtuml.bp.xtext.masl.tests</artifactId>
 	<packaging>eclipse-test-plugin</packaging>

--- a/src/org.xtuml.bp.xtext.masl.parent/org.xtuml.bp.xtext.masl.ui.tests/META-INF/MANIFEST.MF
+++ b/src/org.xtuml.bp.xtext.masl.parent/org.xtuml.bp.xtext.masl.ui.tests/META-INF/MANIFEST.MF
@@ -1,8 +1,8 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: MASL Xtext editor tests
-Bundle-Vendor: OneFact
-Bundle-Version: 1.0.0.qualifier
+Bundle-Vendor: xtUML.org
+Bundle-Version: 6.6.1.qualifier
 Bundle-SymbolicName: org.xtuml.bp.xtext.masl.ui.tests; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.xtuml.bp.xtext.masl.ui,
@@ -11,7 +11,7 @@ Require-Bundle: org.xtuml.bp.xtext.masl.ui,
  org.eclipse.xtext.xbase.junit,
  org.eclipse.core.runtime,
  org.eclipse.ui.workbench;resolution:=optional,
- org.xtuml.bp.xtext.masl;bundle-version="1.0.0"
+ org.xtuml.bp.xtext.masl;bundle-version="6.6.1"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.xtuml.bp.xtext.masl.ui.tests
 Import-Package: org.hamcrest.core,

--- a/src/org.xtuml.bp.xtext.masl.parent/org.xtuml.bp.xtext.masl.ui.tests/pom.xml
+++ b/src/org.xtuml.bp.xtext.masl.parent/org.xtuml.bp.xtext.masl.ui.tests/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.xtuml.bp.xtext.masl</groupId>
 		<artifactId>org.xtuml.bp.xtext.masl.parent</artifactId>
-		<version>1.0.0-SNAPSHOT</version>
+		<version>6.6.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>org.xtuml.bp.xtext.masl.ui.tests</artifactId>
 	<packaging>eclipse-test-plugin</packaging>

--- a/src/org.xtuml.bp.xtext.masl.parent/org.xtuml.bp.xtext.masl.ui/META-INF/MANIFEST.MF
+++ b/src/org.xtuml.bp.xtext.masl.parent/org.xtuml.bp.xtext.masl.ui/META-INF/MANIFEST.MF
@@ -1,8 +1,8 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: MASL Xtext Editor
-Bundle-Vendor: OneFact
-Bundle-Version: 1.0.0.qualifier
+Bundle-Vendor: xtUML.org
+Bundle-Version: 6.6.1.qualifier
 Bundle-SymbolicName: org.xtuml.bp.xtext.masl.ui; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.xtuml.bp.xtext.masl;visibility:=reexport,

--- a/src/org.xtuml.bp.xtext.masl.parent/org.xtuml.bp.xtext.masl.ui/pom.xml
+++ b/src/org.xtuml.bp.xtext.masl.parent/org.xtuml.bp.xtext.masl.ui/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.xtuml.bp.xtext.masl</groupId>
 		<artifactId>org.xtuml.bp.xtext.masl.parent</artifactId>
-		<version>1.0.0-SNAPSHOT</version>
+		<version>6.6.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>org.xtuml.bp.xtext.masl.ui</artifactId>
 	<packaging>eclipse-plugin</packaging>

--- a/src/org.xtuml.bp.xtext.masl.parent/org.xtuml.bp.xtext.masl.updatesite/pom.xml
+++ b/src/org.xtuml.bp.xtext.masl.parent/org.xtuml.bp.xtext.masl.updatesite/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.xtuml.bp.xtext.masl</groupId>
 		<artifactId>org.xtuml.bp.xtext.masl.parent</artifactId>
-		<version>1.0.0-SNAPSHOT</version>
+		<version>6.6.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>org.xtuml.bp.xtext.masl.updatesite</artifactId>
 	<packaging>eclipse-repository</packaging>

--- a/src/org.xtuml.bp.xtext.masl.parent/org.xtuml.bp.xtext.masl/META-INF/MANIFEST.MF
+++ b/src/org.xtuml.bp.xtext.masl.parent/org.xtuml.bp.xtext.masl/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 6.6.1.qualifier
 Bundle-ClassPath: .
 Bundle-SymbolicName: org.xtuml.bp.xtext.masl;singleton:=true
 Bundle-ActivationPolicy: lazy
@@ -17,7 +17,7 @@ Require-Bundle: org.eclipse.xtext,
  org.eclipse.xtext.util,
  org.eclipse.xtend.lib,
  org.eclipse.emf.common,
- org.xtuml.bp.xtext.generator;bundle-version="1.0.0";resolution:=optional,
+ org.xtuml.bp.xtext.generator;bundle-version="6.6.1";resolution:=optional,
  org.eclipse.emf.ecore.xcore.lib;bundle-version="1.1.100",
  org.eclipse.emf.ecore.xcore;bundle-version="1.3.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/src/org.xtuml.bp.xtext.masl.parent/org.xtuml.bp.xtext.masl/plugin.properties
+++ b/src/org.xtuml.bp.xtext.masl.parent/org.xtuml.bp.xtext.masl/plugin.properties
@@ -1,4 +1,4 @@
 #
 
 pluginName = MaslBase Model
-providerName = OneFact
+providerName = xtUML.org

--- a/src/org.xtuml.bp.xtext.masl.parent/org.xtuml.bp.xtext.masl/pom.xml
+++ b/src/org.xtuml.bp.xtext.masl.parent/org.xtuml.bp.xtext.masl/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.xtuml.bp.xtext.masl</groupId>
 		<artifactId>org.xtuml.bp.xtext.masl.parent</artifactId>
-		<version>1.0.0-SNAPSHOT</version>
+		<version>6.6.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>org.xtuml.bp.xtext.masl</artifactId>
 	<packaging>eclipse-plugin</packaging>

--- a/src/org.xtuml.bp.xtext.masl.parent/pom.xml
+++ b/src/org.xtuml.bp.xtext.masl.parent/pom.xml
@@ -8,7 +8,7 @@
 		<relativePath>../../releng/org.xtuml.bp.releng.parent.generation/</relativePath>
 	</parent>
 	<groupId>org.xtuml.bp.xtext.masl</groupId>
-	<version>1.0.0-SNAPSHOT</version>
+	<version>6.6.1-SNAPSHOT</version>
 	<artifactId>org.xtuml.bp.xtext.masl.parent</artifactId>
 	<packaging>pom</packaging>
 


### PR DESCRIPTION
There is no note for this work.  It is simply updating xtext plugins to be version 6.6.1 instead of 1.0.0 and changing the vendor from OneFact to xtUML.org.