### PR TITLE
job #10196 cleaned up error reporting in the x2m plugin

### DIFF
--- a/src/org.xtuml.bp.x2m/src/org/xtuml/bp/x2m/generator/Generator.java
+++ b/src/org.xtuml.bp.x2m/src/org/xtuml/bp/x2m/generator/Generator.java
@@ -41,7 +41,6 @@ import org.xtuml.bp.core.common.PersistableModelComponent;
 import org.xtuml.bp.core.inspector.IModelClassInspector;
 import org.xtuml.bp.core.inspector.ModelInspector;
 import org.xtuml.bp.core.inspector.ObjectElement;
-import org.xtuml.bp.mc.AbstractActivator;
 import org.xtuml.bp.mc.c.source.ExportBuilder;
 
 public class Generator extends Task {
@@ -213,7 +212,7 @@ public class Generator extends Task {
                                     break;
                                 }
                             } catch (Throwable e) {
-                            	RuntimeException err = new RuntimeException(e.getMessage());
+                            	RuntimeException err = new RuntimeException(e);
                                 throw err;
                             } 
                             curStep++;
@@ -223,19 +222,8 @@ public class Generator extends Task {
 
                 openOutput(destPath);
             } catch (Throwable e) {
-                String errMsg = e.getMessage();
-                if ( (errMsg == null) || errMsg.isEmpty() ) {
-                    Throwable cause = e.getCause();
-                    if ( cause != null ) {
-                        errMsg = cause.getMessage();
-                    } 
-                    
-                    if ((cause == null) || (errMsg == null)) {
-                        errMsg = "";
-                    }
-                }
-                logMsg("Error.  MASL export failed: " + errMsg);
-                CorePlugin.logError("Error.  MASL export failed: " + errMsg, e);
+                logMsg("Error. MASL export failed. See error log for more detail.");
+                CorePlugin.logError("Error. MASL export failed.", e);
                 failed = true;
             } finally {
                 if (failed) {
@@ -243,12 +231,8 @@ public class Generator extends Task {
                         cleanup(destPath);
                         project.refreshLocal(IResource.DEPTH_INFINITE, null);
                     } catch (CoreException ce) {
-                        String errMsg = ce.getMessage();
-                        if ( (errMsg == null) || errMsg.isEmpty() ) {
-                            errMsg = "CoreException";
-                        }
-                        logMsg("Error.  MASL export failed during cleanup: " + errMsg);
-                        CorePlugin.logError("Error.  MASL export failed during cleanup: " + errMsg, ce);
+                        logMsg("Error. MASL export failed during cleanup. See error log for more detail");
+                        CorePlugin.logError("Error. MASL export failed during cleanup.", ce);
                     }
                 } else {
                     logMsg("MASL export finished successfully.");


### PR DESCRIPTION
No note for this one as it is very small. Here is a summary of the changes in line number sequential order:
- removed unused import
- pass `e` instead of `e.getMessage()` to the constructor of the `RuntimeException`. This catch/rethrow pattern was obscuring the real cause (and stack and line information) of exceptions raised. Passing the reference to the `Throwable` instance instead of just the message preserves this information in the error log.
- Remove logic to compile an error message printed to the console. It turns out this was not very useful as it was almost always observed to be an empty string. Instead the error message specifically calls out to the user to look for more detail in the error log itself.
- Repeat of above step for the second try/catch construction

Testing done for this change:
I created three private static void methods `redirect1`, `redirect2`, and `redirect3`. The first calls the second and the second calls the third. In `redirect3` I added the line:
```
((Object)null).toString();   // induce NPE
```
On line 210 (right under `case 5:`), I invoke `redirect1`.

Build and launch BP. Export MASL domain or project on any model. Observe the error.
In the error log I confirmed that I was able to see the whole stack including all the `redirect*` methods and the line number information for all of them tracing back to the NPE.

Note that this code to force an error and test was removed before commit.