### PR TITLE
job:#10345 Fixed test NavigationTest.java

### DIFF
--- a/src/org.xtuml.bp.core/src/org/xtuml/bp/core/PropertyViewListener.java
+++ b/src/org.xtuml.bp.core/src/org/xtuml/bp/core/PropertyViewListener.java
@@ -61,12 +61,12 @@ public class PropertyViewListener implements ITransactionListener {
 						if (d2 == null) {
 							d2 = Ooaofooa.m_display;
 						}
-						if (d2 != null) {
+						if (d2 != null ) {
 							// always run async to prevent infinite loops
 							// when the update comes from the property view
 							d2.asyncExec(new Runnable() {
 								public void run() {
-									if (!psp.getControl().isDisposed())
+									if (psp != null && psp.getControl() != null && !psp.getControl().isDisposed())
 										psp.refresh();
 								}
 							});


### PR DESCRIPTION
In PropertyViewListener::transactionEnded() there is a spot that watches
for the case where the property control has been dsposed. This case
needed an additional null check to prevent an NPE in some cases.