### PR TITLE
11645 seme fix

### DIFF
--- a/src/org.xtuml.bp.ui.marking/src/org/xtuml/bp/ui/marking/MarkingData.java
+++ b/src/org.xtuml.bp.ui.marking/src/org/xtuml/bp/ui/marking/MarkingData.java
@@ -82,8 +82,8 @@ public class MarkingData {
 			inFile.useDelimiter(",|\\r|\\n");
 		} catch (FileNotFoundException fnfe) {
 			// With the change to add the marking listener the data may be attempted to be loaded on a 
-			// project without the .mark files.  We don't want to throw an exception in this case, just log it.
-			System.out.println(fnfe);
+			// project without the .mark files.  This may be fine as not all projects use this style of
+			// marking.  So we don't do anything when the file is not found.
 		}
 		
 		while ( inFile.hasNext() ) {
@@ -121,8 +121,8 @@ public class MarkingData {
 			inFile.useDelimiter(",|\\r|\\n");
 		} catch (FileNotFoundException fnfe) {
 			// With the change to add the marking listener the data may be attempted to be loaded on a 
-			// project without the .mark files.  We don't want to throw an exception in this case, just lot it.
-			System.out.println(fnfe);
+			// project without the .mark files.  This may be fine as not all projects use this style of
+			// marking.  So we don't do anything when the file is not found.
 		}
 		
 		while ( inFile.hasNext() ) {

--- a/src/org.xtuml.bp.ui.sem/src/org/xtuml/bp/ui/sem/pages/SEMEditorPage.java
+++ b/src/org.xtuml.bp.ui.sem/src/org/xtuml/bp/ui/sem/pages/SEMEditorPage.java
@@ -332,14 +332,19 @@ public class SEMEditorPage extends Composite {
 			            		setCursor(fOpenCursor);
 			            		return;
 			            	} else {
-								StateEventMatrixEntry_c entry = getMatrixEntry((StateMachineState_c) item.getData(), event);
-								if(entry != null) {
-									// if this is a new state transition matrix entry
-									// then open the transition activity editor
-									NewStateTransition_c transition = NewStateTransition_c.getOneSM_NSTXNOnR504(entry);
-									if(transition != null) {
-										setCursor(fOpenCursor);
-										return;
+								if (item.getData() instanceof NoStateRow) {
+									// We don't allow editing of a creation transition, so nothing in this row is editable
+									return;
+								} else {
+									StateEventMatrixEntry_c entry = getMatrixEntry((StateMachineState_c) item.getData(), event);
+									if (entry != null) {
+										// if this is a new state transition matrix entry
+										// then open the transition activity editor
+										NewStateTransition_c transition = NewStateTransition_c.getOneSM_NSTXNOnR504(entry);
+										if (transition != null) {
+											setCursor(fOpenCursor);
+											return;
+										}
 									}
 								}
 			            	}
@@ -370,15 +375,20 @@ public class SEMEditorPage extends Composite {
 				            	if(event == null) {
 				            		elementToOpen = item.getData();
 				            	} else {
-									StateEventMatrixEntry_c entry = getMatrixEntry((StateMachineState_c) item.getData(), event);
-									if(entry != null) {
-										// if this is a new state transition matrix entry
-										// then open the transition activity editor
-										NewStateTransition_c transition = NewStateTransition_c.getOneSM_NSTXNOnR504(entry);
-										if(transition != null) {
-											elementToOpen = Transition_c.getOneSM_TXNOnR507(transition);
-										}
-									}
+				            		if (item.getData() instanceof NoStateRow) {
+				            			// We don't allow editing of a creation transition, so nothing in this row is editable
+				            			return;
+				            		} else {
+				            			StateEventMatrixEntry_c entry = getMatrixEntry((StateMachineState_c) item.getData(), event);
+				            			if(entry != null) {
+				            				// if this is a new state transition matrix entry
+				            				// then open the transition activity editor
+				            				NewStateTransition_c transition = NewStateTransition_c.getOneSM_NSTXNOnR504(entry);
+				            				if(transition != null) {
+				            					elementToOpen = Transition_c.getOneSM_TXNOnR507(transition);
+				            				}
+				            			}
+				            		}
 				            	}
 				            }
 				        }


### PR DESCRIPTION
Don't treat NoStateRows like other rows when handling mouse moves.  You're not allowed (in xtUML) to have activity in a creation transition.  So, handle that case properly.