### PR TITLE
Fix for readonly error with by-ref parameter

### DIFF
--- a/doc-bridgepoint/notes/5050_OAL_interface_by_ref_parse_error_int.adoc
+++ b/doc-bridgepoint/notes/5050_OAL_interface_by_ref_parse_error_int.adoc
@@ -1,0 +1,61 @@
+= OAL Parse Interface By-Ref Parameter as Read-only
+
+xtUML Project Implementation Note
+
+== 1 Abstract
+
+The issue describes a legal operation, interface instance calling a
+class/interface operation with a by-reference parameter, but a parse of this
+legal operation results in an error message, "Cannot pass read-only value to
+pass-by-reference parameter. This note documents the fix for this.
+
+== 2 Introduction and Background
+
+Issue <<dr-1, 5050>> has had some previous work done by Cortland Starrett in 
+the addition of an example project, to reproduce the problem, and a note 
+stating, "I think the problem is in OAL Validation Utility 
+Functions::Is_readonly_value."
+
+An xtUML search on the error message shows three OAL Validation functions that
+report the error, and a debug run with a breakpoint set in the java generated
+versions of these functions leads to the aforementioned Is_readonly_value
+function.
+
+== 3 Requirements
+
+== 4 Work Required
+
+. Add Property Parameter case to OAL Validation Utility Functions::Is_readonly_value
+. Update any tests for this functionality
+. Verify change doesn't break unit tests
+. Determine if this fixes other related issues
+
+== 5 Implementation Comments
+
+Issues 10157, 7679, 7678, & 5055 should be checked against this fix.
+
+== 6 Unit Test
+
+== 7 User Documentation
+
+== 8 Code Changes
+
+- fork/repository:  lwriemen/bridgepoint
+- branch:  5050-readonly-byref-parm
+
+----
+ Put the file list here
+----
+
+== 9 Document References
+
+In this section, list all the documents that the reader may need to refer to.
+Give the full path to reference a file.
+
+. [[dr-1]] https://support.onefact.net/issues/5050[5050 - OAL parse error in a port/interface operation with by-reference parameters]
+
+---
+
+This work is licensed under the Creative Commons CC0 License
+
+---

--- a/src/org.xtuml.bp.core/models/org.xtuml.bp.core/ooaofooa/Functions/OAL Validation Utility Functions/OAL Validation Utility Functions.xtuml
+++ b/src/org.xtuml.bp.core/models/org.xtuml.bp.core/ooaofooa/Functions/OAL Validation Utility Functions/OAL Validation Utility Functions.xtuml
@@ -3911,6 +3911,10 @@ if ( not_empty pvl )
   if ( not_empty tparm )
     return tparm.By_Ref == 0;
   end if;
+  select one pparm related by pvl->C_PP[R843];
+  if ( not_empty pparm )
+    return pparm.By_Ref == 0;
+  end if;
 end if;
 
 


### PR DESCRIPTION
This adds a case for the fourth parameter value type related to V_PVL to
the OAL Validation Utility Functions::Is_readonly_value function.