### PR TITLE
job #11724 - Add associative class valid check

### DIFF
--- a/doc-bridgepoint/notes/11719_associative_valid_check/11719_associative_valid_check_int.adoc
+++ b/doc-bridgepoint/notes/11719_associative_valid_check/11719_associative_valid_check_int.adoc
@@ -1,0 +1,65 @@
+= Coverage Option
+
+xtUML Project Implementation Note
+
+== 1 Abstract
+
+The CME for editing associations was created to handle simple and associative
+relationships. The issue raised is due to a situation where there is no
+possibility of an associative relationship due to a lack of candidate classes to
+fill the role of associative class. This note documents the work to validate the
+availability of a class to fill the associative role.
+
+== 2 Introduction and Background
+
+In issue <<dr-1,11554>>, a new feature was added to enable editing of
+associations via a pop-up dialog. The work allowed automatic formalization of
+simple and associative relationships and allowed automatic linkage of a class as
+an associative class.
+
+As is common in new feature development, some additional work or issues didn't
+get captured until there was enough usage of the feature.
+
+== 3 Requirements
+
+=== 3.1 Add validation of associative class candidates
+
+=== 3.2 Ensure usability remains unchanged
+
+== 4 Work Required
+
+=== 4.1 R_REL_BinaryEditAssociation fix
+Examination of the OAL in this function showed that there was no validation of
+the existence of candidate classes for use as an associative class. This caused
+an array out of bounds exception due to the algorithms in place for accessing a
+list of candidate classes.
+
+A conditional check was added to the OAL where the array of candidate
+associative classes is created to prevent creation of a negative sized array.
+
+
+== 5 Implementation Comments
+
+none
+
+== 6 Unit Test
+
+
+== 7 User Documentation
+
+
+== 8 Code Changes
+
+- fork/repository:  lwriemen/bridgepoint
+- branch:  11554-associative-valid-check
+
+
+== 9 Document References
+
+. [[dr-1]] https://support.onefact.net/issues/11554[11554 - Automatically formalize and force user to setup referentials and role phrases at creation
+
+---
+
+This work is licensed under the Creative Commons CC0 License
+
+---

--- a/src/org.xtuml.bp.core/models/org.xtuml.bp.core/ooaofooa/Functions/Context Menu Entry Functions/Context Menu Entry Functions.xtuml
+++ b/src/org.xtuml.bp.core/models/org.xtuml.bp.core/ooaofooa/Functions/Context Menu Entry Functions/Context Menu Entry Functions.xtuml
@@ -8079,31 +8079,34 @@ select many associative_imported_classes related by r_rel->PE_PE[R8001]->EP_PKG[
 associative_classes = associative_classes + associative_imported_classes;
 default_selection = 0;
 num_options = cardinality associative_classes;
-associative_class_options[num_options-1] = "";
-i = num_options - 1;
-for each associative_class in associative_classes
-  associative_class_options[i] = associative_class.Name;
-  i = i - 1;
-end for;
-// Bubble sort list of associative classes.
-i = 0;
-while ( i < (num_options-1) )
-  j = 0;
-  while ( j < (num_options-i-1) )
-    s1 = associative_class_options[j]; s2 = associative_class_options[j+1];
-    if ( s1 > s2 )
-      s = associative_class_options[j];
-      associative_class_options[j] = associative_class_options[j+1];
-      associative_class_options[j+1] = s;
+associative_class_options[num_options] = "";
+if (0 < num_options)
+  associative_class_options[num_options-1] = "";
+  i = num_options - 1;
+  for each associative_class in associative_classes
+    associative_class_options[i] = associative_class.Name;
+    i = i - 1;
+  end for;
+  // Bubble sort list of associative classes.
+  i = 0;
+  while ( i < (num_options-1) )
+    j = 0;
+    while ( j < (num_options-i-1) )
+      s1 = associative_class_options[j]; s2 = associative_class_options[j+1];
+      if ( s1 > s2 )
+        s = associative_class_options[j];
+        associative_class_options[j] = associative_class_options[j+1];
+        associative_class_options[j+1] = s;
+      end if;
+      j = j + 1;
+    end while;
+    s3 = associative_class_options[i];
+    if not_empty assr and assr.Name == s3
+      default_selection = i;
     end if;
-    j = j + 1;
+    i = i + 1;
   end while;
-  s3 = associative_class_options[i];
-  if not_empty assr and assr.Name == s3
-    default_selection = i;
-  end if;
-  i = i + 1;
-end while;
+end if;
 assoc_class = USER::getDropdown(options:associative_class_options, prompt:"Associative class", default_selection:default_selection, reload_options:false);
 LAYOUT::setLayout(field_name:"assoc_class", row_num:"4", width:"1", height:"1");
 select any associative_class related by r_rel->PE_PE[R8001]->EP_PKG[R8000]->PE_PE[R8000]->O_OBJ[R8001] where (selected.Name == assoc_class);


### PR DESCRIPTION
In the CME, a check for valid associative class candidates was added to
the associative class candidate list creation.