### PR TITLE
11787 masl disappearing marks

### DIFF
--- a/doc-bridgepoint/notes/11787-mark-update-issues/11787-mark-update-issues-ant.adoc
+++ b/doc-bridgepoint/notes/11787-mark-update-issues/11787-mark-update-issues-ant.adoc
@@ -1,0 +1,61 @@
+= Unintended Marking Deletions Issue Analysis Note
+:numbered:
+:sectnums:
+:sectnumlevels: 5
+
+xtUML Project Analysis Note
+
+== Abstract
+
+Unintended deletions are being made to the application.mark files when model
+elements are renamed or moved.
+
+== Introduction and Background
+
+The application.mark support in BridgePoint was originally set up to be updated
+via manual operation only; manual operation was either direct edit of the file,
+or via the Marking Editor tool. In issue <<dr-2,11634>>, automated update of the
+file was added.
+
+== Requirements
+
+=== Ensure order of operations is correct
+
+The application.mark file shouldn't be updated until the editor changes have
+been finalized in the areas the application.mark parser monitors.
+
+=== Update Marking Editor help file
+
+Marking Editor help file states that the application.mark file will not be
+modified for renamed or removed elements, but issue <<dr-2,11634>> changed that
+approach to be automated. The help file should be amended to indicate this and
+list any updated information needed by the user.
+
+=== Add support for asterix as _path_ mark and _markable element type_ mark
+
+Support of asterix for these two marks is requested for supporting the Ciera project.
+
+== Analysis
+
+=== Known parsing areas
+
+The application.mark parsing is done in:
+- getPathKey
+- getNRMEForMark
+- recalculatePathKeys
+- getMarks
+
+== Work Required
+_to be specified in the design note_
+
+== Acceptance Test
+_to be specified in the design note_
+
+== Document References
+. [[dr-1]] https://support.onefact.net/issues/11787[11787 - Project markings are removed in different scenarios]
+. [[dr-2]] https://support.onefact.net/issues/11634[11634 - Keep marks in sync with changing model elements]
+---
+
+This work is licensed under the Creative Commons CC0 License
+
+---

--- a/doc-bridgepoint/notes/11787-mark-update-issues/11787-mark-update-issues-ant.adoc
+++ b/doc-bridgepoint/notes/11787-mark-update-issues/11787-mark-update-issues-ant.adoc
@@ -50,29 +50,27 @@ The application.mark parsing is done in:
 ** It has been observed to work on occasion.
 * [[ref-c,other container mark deletion]]Other marks not associated with the change have been deleted.
 ** The other marks were deleted were in a different container at a peer level to the change container. e.g., `CTR::CTR::CTR vs CTR::CTR::OTH`.
-** The other mark deletion was observed with class name change, key letter change, and method name change.
+** The other mark deletion was observed with class name change, key letter change, and method name change, and didn't require a change to data actually in application.mark.
 * [[ref-b,use of asterix]]Any marks containing an `*` are removed.
+* [[ref-d,marking data initialization]]The MarkingData initialization sometimes 
+returns Marks with null nrme attributes. 
 
 ==== Code Handling
-* For the <<ref-a>> observation, it was found that the _path_ element of the
- mark contained the class name, and the _path_ element was used to determine
- the validity of the root element, i.e., the class. If the order of operations
- was correct, i.e., class name is changed before end of transaction processing,
- this will cause a failure, because the old class name doesn't match the new
- class name. This is also the reason for the <<ref-b>> issue with respect to an
- `*` for the _path_ of the mark.
-* TBD for <<ref-c>>
+* For the <<ref-a>> observation, mark data has the nrme attribute set to null, 
+which causes the path to be invalidated, or the call to getNRMEForMark with the
+new class name returns null, which causes the path to be invalidated. The
+recalculatePathKeys call removes marks with invalid paths, as it assumes they
+are scheduled for deletion.
+* The observed bahavior for <<ref-c>>, with respect to the marks being deleted, 
+is that they are also returning an invalid path.
 * TBD for <<ref-b>> for the _markable element type_.
 
 === Order of operations
 
-The observation that the class rename sometimes updates the application.mark
-file correctly means that the marking update occured before the actual class 
-rename occured.
-
-According to <<dr-4>>, transactions are handled via asynchronous events to all
-transaction listeners. Asynchronous events can't be guaranteed to have an
-established order, so the marking update must be able to handle both situations.
+* For the <<ref-d>>, the null attributes can appear in any order, which suggests
+that model loading isn't done sequentially.
+* For the <<ref-a>>, there appears to be a race condition with class name 
+change in the loaded model and the marking data transaction end processing.
 
 == Work Required
 

--- a/doc-bridgepoint/notes/11787-mark-update-issues/11787-mark-update-issues-ant.adoc
+++ b/doc-bridgepoint/notes/11787-mark-update-issues/11787-mark-update-issues-ant.adoc
@@ -56,11 +56,12 @@ The application.mark parsing is done in:
 returns Marks with null nrme attributes. 
 
 ==== Code Handling
+
+=== Mark deletion
+
 * For the <<ref-a>> observation, mark data has the nrme attribute set to null, 
-which causes the path to be invalidated, or the call to getNRMEForMark with the
-new class name returns null, which causes the path to be invalidated. The
-recalculatePathKeys call removes marks with invalid paths, as it assumes they
-are scheduled for deletion.
+which causes the path to be invalidated. The recalculatePathKeys call removes 
+marks with invalid paths, as it assumes they are scheduled for deletion.
 * The observed bahavior for <<ref-c>>, with respect to the marks being deleted, 
 is that they are also returning an invalid path.
 * The MarkingData initialization as well as the path recalculation doesn't 
@@ -70,9 +71,17 @@ fails.
 === Order of operations
 
 * For the <<ref-d>>, the null nrme attributes can appear in any order, which 
-suggests that model loading isn't done sequentially.
-* For the <<ref-a>>, there appears to be a race condition with class name 
-change in the loaded model and the marking data transaction end processing.
+suggests that model loading isn't done sequentially. There is a race condition
+between the model loading and the initialization of the marking data. If the
+mark element isn't loaded yet, the attempt to find it's NRME returns null.
+* For the <<ref-a>>, the null nrme is the issue. It is possible to get a valid 
+nrme if the mark can be found, the transaction change applied to the existing
+mark's path, and the nrme obtained from the new path.
+* There are two ways to ensure <<ref-a>> and <<ref-c>> don't occur for valid 
+marking data; 1) Don't initialize the marking data until the model loading is
+finished, and 2) Reinitialize the marking data of makr with a null nrme. The
+reinitialization can't be done at transaction end, as the mark path has already
+changed.
 
 == Work Required
 

--- a/doc-bridgepoint/notes/11787-mark-update-issues/11787-mark-update-issues-ant.adoc
+++ b/doc-bridgepoint/notes/11787-mark-update-issues/11787-mark-update-issues-ant.adoc
@@ -50,6 +50,7 @@ The application.mark parsing is done in:
 ** It has been observed to work on occasion.
 * [[ref-c,other container mark deletion]]Other marks not associated with the change have been deleted.
 ** The other marks were deleted were in a different container at a peer level to the change container. e.g., `CTR::CTR::CTR vs CTR::CTR::OTH`.
+** The other mark deletion was observed with class name change, key letter change, and method name change.
 * [[ref-b,use of asterix]]Any marks containing an `*` are removed.
 
 ==== Code Handling

--- a/doc-bridgepoint/notes/11787-mark-update-issues/11787-mark-update-issues-ant.adoc
+++ b/doc-bridgepoint/notes/11787-mark-update-issues/11787-mark-update-issues-ant.adoc
@@ -63,12 +63,14 @@ recalculatePathKeys call removes marks with invalid paths, as it assumes they
 are scheduled for deletion.
 * The observed bahavior for <<ref-c>>, with respect to the marks being deleted, 
 is that they are also returning an invalid path.
-* TBD for <<ref-b>> for the _markable element type_.
+* The MarkingData initialization as well as the path recalculation doesn't 
+account for <<ref-b>>. Both try to get the path key for a value of '*', which
+fails.
 
 === Order of operations
 
-* For the <<ref-d>>, the null attributes can appear in any order, which suggests
-that model loading isn't done sequentially.
+* For the <<ref-d>>, the null nrme attributes can appear in any order, which 
+suggests that model loading isn't done sequentially.
 * For the <<ref-a>>, there appears to be a race condition with class name 
 change in the loaded model and the marking data transaction end processing.
 

--- a/doc-bridgepoint/notes/11787-mark-update-issues/11787-mark-update-issues-ant.adoc
+++ b/doc-bridgepoint/notes/11787-mark-update-issues/11787-mark-update-issues-ant.adoc
@@ -45,8 +45,37 @@ The application.mark parsing is done in:
 - recalculatePathKeys
 - getMarks
 
+==== Observed behavior
+* [[ref-a,class name change]]Upon class name change, any mark with the class name gets deleted.
+** It has been observed to work on occasion.
+* [[ref-c,other container mark deletion]]Other marks not associated with the change have been deleted.
+** The other marks were deleted were in a different container at a peer level to the change container. e.g., `CTR::CTR::CTR vs CTR::CTR::OTH`.
+* [[ref-b,use of asterix]]Any marks containing an `*` are removed.
+
+==== Code Handling
+* For the <<ref-a>> observation, it was found that the _path_ element of the
+ mark contained the class name, and the _path_ element was used to determine
+ the validity of the root element, i.e., the class. If the order of operations
+ was correct, i.e., class name is changed before end of transaction processing,
+ this will cause a failure, because the old class name doesn't match the new
+ class name. This is also the reason for the <<ref-b>> issue with respect to an
+ `*` for the _path_ of the mark.
+* TBD for <<ref-c>>
+* TBD for <<ref-b>> for the _markable element type_.
+
+=== Order of operations
+
+The observation that the class rename sometimes updates the application.mark
+file correctly means that the marking update occured before the actual class 
+rename occured.
+
+According to <<dr-4>>, transactions are handled via asynchronous events to all
+transaction listeners. Asynchronous events can't be guaranteed to have an
+established order, so the marking update must be able to handle both situations.
+
 == Work Required
-_to be specified in the design note_
+
+Determine best place to handle the possible order cases.
 
 == Acceptance Test
 _to be specified in the design note_
@@ -54,6 +83,8 @@ _to be specified in the design note_
 == Document References
 . [[dr-1]] https://support.onefact.net/issues/11787[11787 - Project markings are removed in different scenarios]
 . [[dr-2]] https://support.onefact.net/issues/11634[11634 - Keep marks in sync with changing model elements]
+. [[dr-3]] https://support.onefact.net/issues/11555[11555 - Renaming signal causes marks to be lost]
+. [[dr-4]] https://github.com/xtuml/bridgepoint/blob/master/doc-bridgepoint/notes/8261_masl_refactor/8261_masl_refactor_dnt.md[8621 Masl Refactor Design Note]
 ---
 
 This work is licensed under the Creative Commons CC0 License

--- a/doc-bridgepoint/notes/11787-mark-update-issues/11787-mark-update-issues-dnt.adoc
+++ b/doc-bridgepoint/notes/11787-mark-update-issues/11787-mark-update-issues-dnt.adoc
@@ -42,29 +42,48 @@ should be predicated upon only this transaction.
 recalculatePathKeys modifies the collected marking data. A fix has to occur
 before or during the call to recalculatePathKeys.
 
-Path issues are due to nrme attribute setting. For a valid set of marks, this
-shouldn't be null, but the race conditions in <<dr-1>> are in play.
+Path issues can be due to nrme attribute setting. For a valid set of named 
+marks, the nrme attribute shouldn't be null, but the race conditions discussed 
+in <<dr-1>> are in play.
+
+The race conditions also come into play when the nrme attribute is valid. In
+this case, the new value for a named element is in place, but the old value is
+being used to recalculate the path.
 
 == Design
 
-=== Keyletter change persist
+=== Value change persist
 
-The keyletter mark data can be updated before the call to recalculatePathKeys,
-so a new MarkingData method will be created to handle it. There is no need to
-run recalculate path keys for a keyletter transaction.
+The mark value attribute data can be updated before the call to recalculate the
+new path, so a new MarkingData method will be created to handle it.
 
-=== Class rename fix
+Some value data updates can also be due to named path changes, so this new
+method and the update path method must both be run for the transaction.
 
+=== Path name change fix
+
+A mechanism for updaating the path name will be added to the path calculation in
+such a manner that the old name will be checked, and then if it fails, the new
+name will be checked. The result handling will then proceed as written.
+
+=== Asterix support
+
+Asterix detection will be added to the path calculation and marks with an
+asterix will not be modified. As asterix support in values isn't required, the
+value update method will not have any special handling for asterix.
 
 == Design Comments
+
+These fixes will not solve all issues with marks getting deleted that might be
+caused by <<dr-2>>.
 
 == User Documentation
 
 == Unit Test
 
 == Document References
-. [[dr-1]]
-https://github.com/xtuml/bridgepoint/blob/master/doc-bridgepoint/notes/11787-mark-update-issues/11787-mark-update-issues-ant.adoc[11787 Mark Update Issues Analysis Note]
+. [[dr-1]] https://github.com/xtuml/bridgepoint/blob/master/doc-bridgepoint/notes/11787-mark-update-issues/11787-mark-update-issues-ant.adoc[11787 Mark Update Issues Analysis Note]
+. [[dr-2]] https://support.onefact.net/issues/11472[11472 - Deadlock during load (parent)]
 ---
 
 This work is licensed under the Creative Commons CC0 License

--- a/doc-bridgepoint/notes/11787-mark-update-issues/11787-mark-update-issues-dnt.adoc
+++ b/doc-bridgepoint/notes/11787-mark-update-issues/11787-mark-update-issues-dnt.adoc
@@ -12,6 +12,7 @@ elements are renamed or moved.
 
 == Introduction and Background
 
+See <<dr-1>>.
 
 == Requirements
 
@@ -38,12 +39,19 @@ The issue with an element change only occurs when the path is modified; this
 occurs for DELTA_ATTRIBUTE_CHANGE transactions only. Any algorithm changes
 should be predicated upon only this transaction.
 
+recalculatePathKeys modifies the collected marking data. A fix has to occur
+before or during the call to recalculatePathKeys.
+
 == Design
 
-The transaction end event will call MarkingData.recalculatePathKeys using the 
-marking data containing the old value, then if that call fails, the marking data
-will be updated with the changed value, MarkingData.recalculatePathKeys will 
-check for the new value, and the rest of the algorithm will proceed as normal.
+=== Keyletter change persist
+
+The keyletter mark data can be updated before the call to recalculatePathKeys,
+so a new MarkingData method will be created to handle it. There is no need to
+run recalculate path keys for a keyletter transaction.
+
+=== Class rename fix
+
 
 == Design Comments
 

--- a/doc-bridgepoint/notes/11787-mark-update-issues/11787-mark-update-issues-dnt.adoc
+++ b/doc-bridgepoint/notes/11787-mark-update-issues/11787-mark-update-issues-dnt.adoc
@@ -62,7 +62,7 @@ method and the update path method must both be run for the transaction.
 
 === Path name change fix
 
-A mechanism for updaating the path name will be added to the path calculation in
+A mechanism for updating the path name will be added to the path calculation in
 such a manner that the old name will be checked, and then if it fails, the new
 name will be checked. The result handling will then proceed as written.
 

--- a/doc-bridgepoint/notes/11787-mark-update-issues/11787-mark-update-issues-dnt.adoc
+++ b/doc-bridgepoint/notes/11787-mark-update-issues/11787-mark-update-issues-dnt.adoc
@@ -1,0 +1,62 @@
+= Unintended Marking Deletions Issue Design Note
+:numbered:
+:sectnums:
+:sectnumlevels: 5
+
+xtUML Project Analysis Note
+
+== Abstract
+
+Unintended deletions are being made to the application.mark files when model
+elements are renamed or moved.
+
+== Introduction and Background
+
+
+== Requirements
+
+See <<dr-1>>.
+
+== Analysis
+
+See <<dr-1>> for explanation of what is occuring.
+
+Exploration using the debugger has shown that insufficient information is
+available at MarkTransactionListener.start function, so all handling needs to 
+occur at the end of transaction. 
+
+The IModelChangeListener was also evaluated as another option, but this occurs 
+before the transaction handling. There would be no recourse for cancellation or
+undoing the transaction.
+
+The point in the end of transaction handling where the problem occurs is at the
+MarkingData.recalculatePathKeys function call; right before this call, the
+marking data is collected, and the marking data contents are stale with respect
+to the change.
+
+The issue with an element change only occurs when the path is modified; this
+occurs for DELTA_ATTRIBUTE_CHANGE transactions only. Any algorithm changes
+should be predicated upon only this transaction.
+
+== Design
+
+The transaction end event will call MarkingData.recalculatePathKeys using the 
+marking data containing the old value, then if that call fails, the marking data
+will be updated with the changed value, MarkingData.recalculatePathKeys will 
+check for the new value, and the rest of the algorithm will proceed as normal.
+
+== Design Comments
+
+== User Documentation
+
+== Unit Test
+
+== Document References
+. [[dr-1]]
+https://github.com/xtuml/bridgepoint/blob/master/doc-bridgepoint/notes/11787-mark-update-issues/11787-mark-update-issues-ant.adoc[11787 Mark Update Issues Analysis Note]
+---
+
+This work is licensed under the Creative Commons CC0 License
+
+---
+

--- a/doc-bridgepoint/notes/11787-mark-update-issues/11787-mark-update-issues-dnt.adoc
+++ b/doc-bridgepoint/notes/11787-mark-update-issues/11787-mark-update-issues-dnt.adoc
@@ -42,6 +42,9 @@ should be predicated upon only this transaction.
 recalculatePathKeys modifies the collected marking data. A fix has to occur
 before or during the call to recalculatePathKeys.
 
+Path issues are due to nrme attribute setting. For a valid set of marks, this
+shouldn't be null, but the race conditions in <<dr-1>> are in play.
+
 == Design
 
 === Keyletter change persist

--- a/doc-bridgepoint/notes/11787-mark-update-issues/11787-mark-update-issues-int.adoc
+++ b/doc-bridgepoint/notes/11787-mark-update-issues/11787-mark-update-issues-int.adoc
@@ -1,0 +1,53 @@
+= Unintended Marking Deletions Issue Implementation Note
+
+xtUML Project Implementation Note
+
+== 1 Abstract
+
+== 2 Introduction and Background
+
+== 3 Requirements
+
+== 4 Work Required
+
+=== 4.1 Keyletter change persist
+
+Added new method to MarkingData.java, MarkingData::updatekeyLetterData. The
+method searches the collected marking data and updates marks with the same value
+as the old key letter to have a value of the new keyletter. The method returns
+true, if the marking data was updated. The return is needed as the transaction
+might not have a representative mark for the change.
+
+The method is called from MarkTransactionListener::transactionEnded, after the
+marking data is collected, but before path keys are recalculated, as the path
+key recalculation can modify the marking data.
+
+=== 4.2 Class rename fix
+
+== 5 Implementation Comments
+
+== 6 Unit Test
+
+
+== 7 User Documentation
+
+
+== 8 Code Changes
+
+- fork/repository: lwriemen/bridgepoint
+- branch:  11787-masl-disappearing-marks
+----
+ Put the file list here
+----
+
+== 9 Document References
+. [[dr-1]]
+https://github.com/xtuml/bridgepoint/blob/master/doc-bridgepoint/notes/11787-mark-update-issues/11787-mark-update-issues-ant.adoc[11787 Mark Update Issues Analysis Note]
+. [[dr-2]]
+https://github.com/xtuml/bridgepoint/blob/master/doc-bridgepoint/notes/11787-mark-update-issues/11787-mark-update-issues-dnt.adoc[11787 Mark Update Issues Design Note]
+
+---
+
+This work is licensed under the Creative Commons CC0 License
+
+---

--- a/doc-bridgepoint/notes/11787-mark-update-issues/11787-mark-update-issues-int.adoc
+++ b/doc-bridgepoint/notes/11787-mark-update-issues/11787-mark-update-issues-int.adoc
@@ -19,10 +19,21 @@ true, if the marking data was updated. The return is needed as the transaction
 might not have a representative mark for the change.
 
 The method is called from MarkTransactionListener::transactionEnded, after the
-marking data is collected, but before path keys are recalculated, as the path
-key recalculation can modify the marking data.
+marking data is collected, and will block the call to recalculatePathKeys. The
+method call is predicated upon an attribute name of "Key_lett".
 
 === 4.2 Class rename fix
+
+Added new method to MarkingData.java, MarkingData::updateClassNameData. The
+method searches the collected marking data and updates marks with the same path
+endings as the old class name to have a value of the new class name. The method 
+returns true, if the marking data was updated. The return is needed as the 
+transaction might not have a representative mark for the change.
+
+The method is called from MarkTransactionListener::transactionEnded, after the
+marking data is collected and will block the call to recalculatePathKeys. The
+method call is predicated upon an attribute name of "Name" and an attribute
+model element instance of ModelClass_c.
 
 == 5 Implementation Comments
 

--- a/doc-bridgepoint/notes/11787-mark-update-issues/11787-mark-update-issues-int.adoc
+++ b/doc-bridgepoint/notes/11787-mark-update-issues/11787-mark-update-issues-int.adoc
@@ -10,35 +10,80 @@ xtUML Project Implementation Note
 
 == 4 Work Required
 
-=== 4.1 Keyletter change persist
+=== 4.1 Value change persist
 
-Added new method to MarkingData.java, MarkingData::updatekeyLetterData. The
-method searches the collected marking data and updates marks with the same value
-as the old key letter to have a value of the new keyletter. The method returns
-true, if the marking data was updated. The return is needed as the transaction
-might not have a representative mark for the change.
+Added new method to MarkingData.java, MarkingData::updateValueData. The
+method searches the collected marking data and updates marks that have the 
+same value as the old value to be updated to the new value.
 
-The method is called from MarkTransactionListener::transactionEnded, after the
-marking data is collected, and will block the call to recalculatePathKeys. The
-method call is predicated upon an attribute name of "Key_lett".
+The marks also have to have the same NonRootModelElement(NRME), otherwise two 
+different marks with the same value data could get updated. As there is a 
+possible race condition between the initialization of the marking data and the 
+initialization of the model, a null check is performed on the current mark's 
+nrme. If null, then a call is made to getNRMEForMark to attempt to get a valid 
+NRME. 
 
-=== 4.2 Class rename fix
-
-Added new method to MarkingData.java, MarkingData::updateClassNameData. The
-method searches the collected marking data and updates marks with the same path
-endings as the old class name to have a value of the new class name. The method 
-returns true, if the marking data was updated. The return is needed as the 
-transaction might not have a representative mark for the change.
+The method returns true, if the marking data was updated.
 
 The method is called from MarkTransactionListener::transactionEnded, after the
-marking data is collected and will block the call to recalculatePathKeys. The
-method call is predicated upon an attribute name of "Name" and an attribute
-model element instance of ModelClass_c.
+marking data is collected and before the call to recalculatePathKeys. The method
+call is predicated upon the transaction being a DELTA_ATTRIBUTE_CHANGE.
+
+=== 4.2 Path name change fix
+
+Changed MarkingData.java method, recalculatePathKeys, to include a retry
+mechanism, if the call to getPathKey fails to produce a valid path key. The
+retry mechanism requires data about the transaction, so the deltaToHandle value
+is passed as a new parameter.
+
+The retry mechanism first modifies the path with the new value. This might
+require multiple retries, as a path can contain multiples of the same string.
+e.g., A package named, ALU, contains a component named, ALU, which contains a 
+package named, ALU, and results in a path of ALU::ALU::ALU, so a change of the
+component name to ALG means the new path needs to be named ALU::ALG::ALU. Each
+rename candidate is passed to getPathKey until a valid key is found or all
+substitutions have been exhausted. i.e., possible substitutions are: 
+ALG::ALU::ALU, ALU::ALG::ALU, or ALU::ALU::ALG.
+
+After the retry mechanism is complete, the same marking data update method as
+used in the previous recalculatePathKeys is performed.
+
+The method is called from MarkTransactionListener::transactionEnded, after the
+marking data is collected and the call to updateValueData. Both the calls to
+updateValueData and recalculatePathKeys are performed, and if either indicates
+a marking data update was performed, then the marking data is persisted.
+
+=== 4.3 Asterix support
+
+Support wwas added to MarkingData.java methods, updateValueData, updateFeature 
+and recalculatePathKeys. 
+
+In updateFeature, a check was added before the value of Mark.nrme is written, 
+and if an asterix is in the path, Mark.nrme is set to null (unknowable).
+
+In recalculatePathKeys, a check was added at the start of the path processing.
+If the element's path is an asterix, then the mark data is retained unchanged,
+otherwise the path processing proceeds.
+
+In updateValueData a check for asterix is placed in case of a null NRME. As the
+asterix indicates that the value applies to multiple elements.
+
+=== 4.4 Exclusion of non-mark processing.
+
+MarkingData::recalculatePathKeys was modified to add a check if the current
+element's path contains the old value of a DELTA_ATTRIBUTE_CHANGE transaction. 
+If the current element's path doesn't contain the old value, there's no reason 
+to continue checking it. The mark data is retained unchanged.
 
 == 5 Implementation Comments
 
+The race condition between the model loading and marking data initialization
+makes this issue impossible to fix completely.
+
 == 6 Unit Test
 
+No unit tests were added or chagned for this issue. Added unit tests could check
+for value changes or asterix handling.
 
 == 7 User Documentation
 

--- a/src/org.xtuml.bp.ui.marking/src/org/xtuml/bp/ui/marking/MarkTransactionListener.java
+++ b/src/org.xtuml.bp.ui.marking/src/org/xtuml/bp/ui/marking/MarkTransactionListener.java
@@ -41,26 +41,16 @@ public class MarkTransactionListener implements ITransactionListener {
                      IProject project = (IProject) ((SystemModel_c) sys_nrme).getAdapter(IProject.class);
                      if ( project != null ) {
                         MarkingData md = MarkingDataManager.getMarkingData(project);
-                        if (md.verifyMarkingData(deltaToHandle)) {
-                           boolean rpk = false;
-                           // Update a key letter change here, as recalculatePathKeys doesn't handle it.
-                           if ( deltaKind == Modeleventnotification_c.DELTA_ATTRIBUTE_CHANGE ) { 
-                              AttributeChangeModelDelta change = (AttributeChangeModelDelta)deltaToHandle;
-                              if ("Key_lett" == change.getAttributeName()) {
-                                  rpk = md.updateKeyletterData(change.getNewValue().toString(), change.getOldValue().toString());
-                              } else {
-                            	  /*
-                                 if ( ("Name" == change.getAttributeName()) && 
-                                     (change.getModelElement() instanceof ModelClass_c) ) {
-                                    rpk = md.updateClassNameData(change.getNewValue().toString(), change.getOldValue().toString());
-                                 }
-                                 */
-                              }
-                           }
-                           if (rpk || md.recalculatePathKeys()) {
-                              // If the marks were updated then persist them
-                              md.persist();
-                           }
+                        // Update a mark value change here, as recalculatePathKeys doesn't handle it.
+                        boolean valueDataUpdated = false;
+                        if ( deltaKind == Modeleventnotification_c.DELTA_ATTRIBUTE_CHANGE ) { 
+                           AttributeChangeModelDelta change = (AttributeChangeModelDelta)deltaToHandle;
+                           valueDataUpdated = md.updateValueData(change.getNewValue().toString(), change.getOldValue().toString());
+                        }
+                        boolean pathDataUpdated = md.verifyPathData(deltaToHandle);
+                        if (valueDataUpdated || pathDataUpdated) {
+                           // If the marks were updated then persist them
+                           md.persist();
                         }
                      }
                   }

--- a/src/org.xtuml.bp.ui.marking/src/org/xtuml/bp/ui/marking/MarkTransactionListener.java
+++ b/src/org.xtuml.bp.ui.marking/src/org/xtuml/bp/ui/marking/MarkTransactionListener.java
@@ -41,7 +41,7 @@ public class MarkTransactionListener implements ITransactionListener {
                      IProject project = (IProject) ((SystemModel_c) sys_nrme).getAdapter(IProject.class);
                      if ( project != null ) {
                         MarkingData md = MarkingDataManager.getMarkingData(project);
-                        if (md.verifyMarkingData()) {
+                        if (md.verifyMarkingData(deltaToHandle)) {
                            boolean rpk = false;
                            // Update a key letter change here, as recalculatePathKeys doesn't handle it.
                            if ( deltaKind == Modeleventnotification_c.DELTA_ATTRIBUTE_CHANGE ) { 
@@ -49,10 +49,12 @@ public class MarkTransactionListener implements ITransactionListener {
                               if ("Key_lett" == change.getAttributeName()) {
                                   rpk = md.updateKeyletterData(change.getNewValue().toString(), change.getOldValue().toString());
                               } else {
+                            	  /*
                                  if ( ("Name" == change.getAttributeName()) && 
                                      (change.getModelElement() instanceof ModelClass_c) ) {
                                     rpk = md.updateClassNameData(change.getNewValue().toString(), change.getOldValue().toString());
                                  }
+                                 */
                               }
                            }
                            if (rpk || md.recalculatePathKeys()) {

--- a/src/org.xtuml.bp.ui.marking/src/org/xtuml/bp/ui/marking/MarkTransactionListener.java
+++ b/src/org.xtuml.bp.ui.marking/src/org/xtuml/bp/ui/marking/MarkTransactionListener.java
@@ -4,6 +4,7 @@ import org.eclipse.core.resources.IProject;
 import org.xtuml.bp.core.DataType_c;
 import org.xtuml.bp.core.Modeleventnotification_c;
 import org.xtuml.bp.core.SystemModel_c;
+import org.xtuml.bp.core.common.AttributeChangeModelDelta;
 import org.xtuml.bp.core.common.IModelDelta;
 import org.xtuml.bp.core.common.ITransactionListener;
 import org.xtuml.bp.core.common.ModelRoot;
@@ -39,7 +40,15 @@ public class MarkTransactionListener implements ITransactionListener {
             			IProject project = (IProject) ((SystemModel_c) sys_nrme).getAdapter(IProject.class);
             			if ( project != null ) {
             				MarkingData md = MarkingDataManager.getMarkingData(project);
-            				if (md.recalculatePathKeys()) {
+            				boolean rpk = false;
+            				// Update a key letter change here, as recalculatePathKeys doesn't handle it.
+            				if ( deltaKind == Modeleventnotification_c.DELTA_ATTRIBUTE_CHANGE ) { 
+            					AttributeChangeModelDelta change = (AttributeChangeModelDelta)deltaToHandle;
+            					if ("Key_lett" == change.getAttributeName()) {
+            					    rpk = md.updateKeyletterData(change.getNewValue().toString(), change.getOldValue().toString());
+            					}
+            				}
+            				if (rpk || md.recalculatePathKeys()) {
             					// If the marks were updated then persist them
             					md.persist();
             				}

--- a/src/org.xtuml.bp.ui.marking/src/org/xtuml/bp/ui/marking/MarkTransactionListener.java
+++ b/src/org.xtuml.bp.ui.marking/src/org/xtuml/bp/ui/marking/MarkTransactionListener.java
@@ -22,45 +22,45 @@ public class MarkTransactionListener implements ITransactionListener {
     }
 
     public void transactionEnded(Transaction transaction) {
-    	if (transaction.getType().equals(Transaction.AUTORECONCILE_TYPE)) { return; }
-    	
+      if (transaction.getType().equals(Transaction.AUTORECONCILE_TYPE)) { return; }
+      
         ModelRoot[] modelRoots = transaction.getParticipatingModelRoots();
         for (int i = 0; i < modelRoots.length; i++ ){
             IModelDelta[] modelDeltas = transaction.getDeltas(modelRoots[i]);
             for (IModelDelta deltaToHandle : modelDeltas) {
-            	int deltaKind = deltaToHandle.getKind();
-            	if ( (deltaKind == Modeleventnotification_c.DELTA_NEW) ||
-            		 (deltaKind == Modeleventnotification_c.DELTA_DELETE) ||
-            		 (deltaKind == Modeleventnotification_c.DELTA_ATTRIBUTE_CHANGE) ||
-            		 (deltaKind == Modeleventnotification_c.DELTA_MODEL_ELEMENT_MOVE) ||
-            		 isDataTypeChange(deltaToHandle)
-            	   ) {
-            		NonRootModelElement nrme = ((NonRootModelElement) deltaToHandle.getModelElement());
-            		NonRootModelElement sys_nrme = nrme.getRoot();
-            		if (sys_nrme instanceof SystemModel_c) {
-            			IProject project = (IProject) ((SystemModel_c) sys_nrme).getAdapter(IProject.class);
-            			if ( project != null ) {
-            				MarkingData md = MarkingDataManager.getMarkingData(project);
-            				boolean rpk = false;
-            				// Update a key letter change here, as recalculatePathKeys doesn't handle it.
-            				if ( deltaKind == Modeleventnotification_c.DELTA_ATTRIBUTE_CHANGE ) { 
-            					AttributeChangeModelDelta change = (AttributeChangeModelDelta)deltaToHandle;
-            					if ("Key_lett" == change.getAttributeName()) {
-            					    rpk = md.updateKeyletterData(change.getNewValue().toString(), change.getOldValue().toString());
-            					} else {
-            						if ( ("Name" == change.getAttributeName()) && 
-            							 (change.getModelElement() instanceof ModelClass_c) ) {
-            							rpk = md.updateClassNameData(change.getNewValue().toString(), change.getOldValue().toString());
-            						}
-            					}
-            				}
-            				if (rpk || md.recalculatePathKeys()) {
-            					// If the marks were updated then persist them
-            					md.persist();
-            				}
-            			}
-            		}
-            	}
+               int deltaKind = deltaToHandle.getKind();
+               if ( (deltaKind == Modeleventnotification_c.DELTA_NEW) ||
+                   (deltaKind == Modeleventnotification_c.DELTA_DELETE) ||
+                   (deltaKind == Modeleventnotification_c.DELTA_ATTRIBUTE_CHANGE) ||
+                   (deltaKind == Modeleventnotification_c.DELTA_MODEL_ELEMENT_MOVE) ||
+                   isDataTypeChange(deltaToHandle)
+                  ) {
+                  NonRootModelElement nrme = ((NonRootModelElement) deltaToHandle.getModelElement());
+                  NonRootModelElement sys_nrme = nrme.getRoot();
+                  if (sys_nrme instanceof SystemModel_c) {
+                     IProject project = (IProject) ((SystemModel_c) sys_nrme).getAdapter(IProject.class);
+                     if ( project != null ) {
+                        MarkingData md = MarkingDataManager.getMarkingData(project);
+                        boolean rpk = false;
+                        // Update a key letter change here, as recalculatePathKeys doesn't handle it.
+                        if ( deltaKind == Modeleventnotification_c.DELTA_ATTRIBUTE_CHANGE ) { 
+                           AttributeChangeModelDelta change = (AttributeChangeModelDelta)deltaToHandle;
+                           if ("Key_lett" == change.getAttributeName()) {
+                               rpk = md.updateKeyletterData(change.getNewValue().toString(), change.getOldValue().toString());
+                           } else {
+                              if ( ("Name" == change.getAttributeName()) && 
+                                  (change.getModelElement() instanceof ModelClass_c) ) {
+                                 rpk = md.updateClassNameData(change.getNewValue().toString(), change.getOldValue().toString());
+                              }
+                           }
+                        }
+                        if (rpk || md.recalculatePathKeys()) {
+                           // If the marks were updated then persist them
+                           md.persist();
+                        }
+                     }
+                  }
+               }
             }
         }
     }
@@ -69,16 +69,16 @@ public class MarkTransactionListener implements ITransactionListener {
      * @return  True if the delta is for a model element changing datatype, otherwise false.
      */
     public boolean isDataTypeChange(IModelDelta delta) {
-		if ( (delta.getKind() == Modeleventnotification_c.DELTA_ELEMENT_RELATED)  ||
-		     (delta.getKind() == Modeleventnotification_c.DELTA_ELEMENT_UNRELATED) 
-		  ) { 
-			RelationshipChangeModelDelta rcmd = (RelationshipChangeModelDelta) delta;
-			Object dest = rcmd.getDestinationModelElement();
-			if (dest instanceof DataType_c) {
-				return true;
-			}
-		}
-		return false;
+      if ( (delta.getKind() == Modeleventnotification_c.DELTA_ELEMENT_RELATED)  ||
+           (delta.getKind() == Modeleventnotification_c.DELTA_ELEMENT_UNRELATED) 
+        ) { 
+         RelationshipChangeModelDelta rcmd = (RelationshipChangeModelDelta) delta;
+         Object dest = rcmd.getDestinationModelElement();
+         if (dest instanceof DataType_c) {
+            return true;
+         }
+      }
+      return false;
     }
     
 }

--- a/src/org.xtuml.bp.ui.marking/src/org/xtuml/bp/ui/marking/MarkTransactionListener.java
+++ b/src/org.xtuml.bp.ui.marking/src/org/xtuml/bp/ui/marking/MarkTransactionListener.java
@@ -2,6 +2,7 @@ package org.xtuml.bp.ui.marking;
 
 import org.eclipse.core.resources.IProject;
 import org.xtuml.bp.core.DataType_c;
+import org.xtuml.bp.core.ModelClass_c;
 import org.xtuml.bp.core.Modeleventnotification_c;
 import org.xtuml.bp.core.SystemModel_c;
 import org.xtuml.bp.core.common.AttributeChangeModelDelta;
@@ -46,6 +47,11 @@ public class MarkTransactionListener implements ITransactionListener {
             					AttributeChangeModelDelta change = (AttributeChangeModelDelta)deltaToHandle;
             					if ("Key_lett" == change.getAttributeName()) {
             					    rpk = md.updateKeyletterData(change.getNewValue().toString(), change.getOldValue().toString());
+            					} else {
+            						if ( ("Name" == change.getAttributeName()) && 
+            							 (change.getModelElement() instanceof ModelClass_c) ) {
+            							rpk = md.updateClassNameData(change.getNewValue().toString(), change.getOldValue().toString());
+            						}
             					}
             				}
             				if (rpk || md.recalculatePathKeys()) {

--- a/src/org.xtuml.bp.ui.marking/src/org/xtuml/bp/ui/marking/MarkTransactionListener.java
+++ b/src/org.xtuml.bp.ui.marking/src/org/xtuml/bp/ui/marking/MarkTransactionListener.java
@@ -2,7 +2,6 @@ package org.xtuml.bp.ui.marking;
 
 import org.eclipse.core.resources.IProject;
 import org.xtuml.bp.core.DataType_c;
-import org.xtuml.bp.core.ModelClass_c;
 import org.xtuml.bp.core.Modeleventnotification_c;
 import org.xtuml.bp.core.SystemModel_c;
 import org.xtuml.bp.core.common.AttributeChangeModelDelta;
@@ -45,9 +44,9 @@ public class MarkTransactionListener implements ITransactionListener {
                         boolean valueDataUpdated = false;
                         if ( deltaKind == Modeleventnotification_c.DELTA_ATTRIBUTE_CHANGE ) { 
                            AttributeChangeModelDelta change = (AttributeChangeModelDelta)deltaToHandle;
-                           valueDataUpdated = md.updateValueData(change.getNewValue().toString(), change.getOldValue().toString());
+                           valueDataUpdated = md.updateValueData(nrme, change.getNewValue().toString(), change.getOldValue().toString());
                         }
-                        boolean pathDataUpdated = md.verifyPathData(deltaToHandle);
+                        boolean pathDataUpdated = md.recalculatePathKeys(deltaToHandle);
                         if (valueDataUpdated || pathDataUpdated) {
                            // If the marks were updated then persist them
                            md.persist();

--- a/src/org.xtuml.bp.ui.marking/src/org/xtuml/bp/ui/marking/MarkTransactionListener.java
+++ b/src/org.xtuml.bp.ui.marking/src/org/xtuml/bp/ui/marking/MarkTransactionListener.java
@@ -42,23 +42,23 @@ public class MarkTransactionListener implements ITransactionListener {
                      if ( project != null ) {
                         MarkingData md = MarkingDataManager.getMarkingData(project);
                         if (md.verifyMarkingData()) {
-                        boolean rpk = false;
-                        // Update a key letter change here, as recalculatePathKeys doesn't handle it.
-                        if ( deltaKind == Modeleventnotification_c.DELTA_ATTRIBUTE_CHANGE ) { 
-                           AttributeChangeModelDelta change = (AttributeChangeModelDelta)deltaToHandle;
-                           if ("Key_lett" == change.getAttributeName()) {
-                               rpk = md.updateKeyletterData(change.getNewValue().toString(), change.getOldValue().toString());
-                           } else {
-                              if ( ("Name" == change.getAttributeName()) && 
-                                  (change.getModelElement() instanceof ModelClass_c) ) {
-                                 rpk = md.updateClassNameData(change.getNewValue().toString(), change.getOldValue().toString());
+                           boolean rpk = false;
+                           // Update a key letter change here, as recalculatePathKeys doesn't handle it.
+                           if ( deltaKind == Modeleventnotification_c.DELTA_ATTRIBUTE_CHANGE ) { 
+                              AttributeChangeModelDelta change = (AttributeChangeModelDelta)deltaToHandle;
+                              if ("Key_lett" == change.getAttributeName()) {
+                                  rpk = md.updateKeyletterData(change.getNewValue().toString(), change.getOldValue().toString());
+                              } else {
+                                 if ( ("Name" == change.getAttributeName()) && 
+                                     (change.getModelElement() instanceof ModelClass_c) ) {
+                                    rpk = md.updateClassNameData(change.getNewValue().toString(), change.getOldValue().toString());
+                                 }
                               }
                            }
-                        }
-                        if (rpk || md.recalculatePathKeys()) {
-                           // If the marks were updated then persist them
-                           md.persist();
-                        }
+                           if (rpk || md.recalculatePathKeys()) {
+                              // If the marks were updated then persist them
+                              md.persist();
+                           }
                         }
                      }
                   }

--- a/src/org.xtuml.bp.ui.marking/src/org/xtuml/bp/ui/marking/MarkTransactionListener.java
+++ b/src/org.xtuml.bp.ui.marking/src/org/xtuml/bp/ui/marking/MarkTransactionListener.java
@@ -41,6 +41,7 @@ public class MarkTransactionListener implements ITransactionListener {
                      IProject project = (IProject) ((SystemModel_c) sys_nrme).getAdapter(IProject.class);
                      if ( project != null ) {
                         MarkingData md = MarkingDataManager.getMarkingData(project);
+                        if (md.verifyMarkingData()) {
                         boolean rpk = false;
                         // Update a key letter change here, as recalculatePathKeys doesn't handle it.
                         if ( deltaKind == Modeleventnotification_c.DELTA_ATTRIBUTE_CHANGE ) { 
@@ -57,6 +58,7 @@ public class MarkTransactionListener implements ITransactionListener {
                         if (rpk || md.recalculatePathKeys()) {
                            // If the marks were updated then persist them
                            md.persist();
+                        }
                         }
                      }
                   }

--- a/src/org.xtuml.bp.ui.marking/src/org/xtuml/bp/ui/marking/MarkingData.java
+++ b/src/org.xtuml.bp.ui.marking/src/org/xtuml/bp/ui/marking/MarkingData.java
@@ -267,6 +267,38 @@ public class MarkingData {
 		
 		return marksUpdated;
 	}
+	public boolean updateNameData(String newAttributeValue, String oldAttributeValue, String attributeName)
+	{
+		LinkedHashMap<String, LinkedHashMap<String,Mark>> newMarkingsMap = new LinkedHashMap<String, LinkedHashMap<String,Mark>>();
+		boolean marksUpdated = false;
+		
+		for (Map.Entry<String, LinkedHashMap<String,Mark>> elementEntry : markingsMap.entrySet()) {
+			LinkedHashMap<String,Mark> newMarkList = new LinkedHashMap<String,Mark>();
+			for ( Map.Entry<String, Mark> featureEntry : elementEntry.getValue().entrySet() ) { 
+				if ( featureEntry.getValue().path.endsWith(oldAttributeValue) ) {
+					String newPath = elementEntry.getKey().substring(0, elementEntry.getKey().lastIndexOf(oldAttributeValue)).concat(newAttributeValue);
+					marksUpdated = true;
+					Mark origMark = featureEntry.getValue();
+					Mark mark = new Mark(); 
+					mark.markable_name = origMark.markable_name; 
+					mark.feature_name = origMark.feature_name; 
+					mark.path = newPath; 
+					mark.value = origMark.value; 
+					mark.nrme = origMark.nrme; 
+					newMarkList.put(newPath, mark);
+				} else {
+					// Unchanged entry
+					newMarkList.put(featureEntry.getKey(), featureEntry.getValue());
+				}
+			}
+			newMarkingsMap.put(elementEntry.getKey(), newMarkList);
+		}
+		// Use the newly updated map of markings
+		if (marksUpdated) {
+			markingsMap = newMarkingsMap;
+		}
+		return marksUpdated;
+	}
 
 	/**
 	 * Write the modified application marking data to disk
@@ -446,4 +478,43 @@ public class MarkingData {
 		}
 		return null;
 	}
+	
+	/**
+	 * Update the keyletter value contained in the mark.
+	 * @param newAttributeValue - the new keyletter
+	 * @param oldAttributeValue - the old keyletter
+	 * @return Indicates if the marking data needs to be persisted.
+	 */
+	public boolean updateKeyletterData(String newAttributeValue, String oldAttributeValue)
+	{
+		LinkedHashMap<String, LinkedHashMap<String,Mark>> newMarkingsMap = new LinkedHashMap<String, LinkedHashMap<String,Mark>>();
+		boolean marksUpdated = false;
+		
+		for (Map.Entry<String, LinkedHashMap<String,Mark>> elementEntry : markingsMap.entrySet()) {
+			LinkedHashMap<String,Mark> newMarkList = new LinkedHashMap<String,Mark>();
+			for ( Map.Entry<String, Mark> featureEntry : elementEntry.getValue().entrySet() ) { 
+				if ( featureEntry.getValue().value.regionMatches(1, oldAttributeValue, 0, oldAttributeValue.length()) ) {
+					marksUpdated = true;
+					Mark origMark = featureEntry.getValue();
+					Mark mark = new Mark(); 
+					mark.markable_name = origMark.markable_name; 
+					mark.feature_name = origMark.feature_name; 
+					mark.path = origMark.path; 
+					mark.value = "\"" + newAttributeValue + "\""; 
+					mark.nrme = origMark.nrme; 
+					newMarkList.put(featureEntry.getKey(), mark);
+				} else {
+					// Unchanged entry
+					newMarkList.put(featureEntry.getKey(), featureEntry.getValue());
+				}
+			}
+			newMarkingsMap.put(elementEntry.getKey(), newMarkList);
+		}
+		// Use the newly updated map of markings
+		if (marksUpdated) {
+			markingsMap = newMarkingsMap;
+		}
+		return marksUpdated;
+	}
+	
 }

--- a/src/org.xtuml.bp.ui.marking/src/org/xtuml/bp/ui/marking/MarkingData.java
+++ b/src/org.xtuml.bp.ui.marking/src/org/xtuml/bp/ui/marking/MarkingData.java
@@ -32,23 +32,23 @@ import org.xtuml.bp.core.common.NonRootModelElement;
 
 public class MarkingData {
 
-	public class Mark {
-		public String markable_name;
-		public String feature_name;
-		public String path;
-		public String value;
-		public NonRootModelElement nrme;
-		
-		public Mark() {
-			markable_name = new String("");
-			feature_name = new String("");
-			path = new String("");
-			value = new String("");
-			nrme = null;
-		}
-	}
-	
-	private IProject project;
+   public class Mark {
+      public String markable_name;
+      public String feature_name;
+      public String path;
+      public String value;
+      public NonRootModelElement nrme;
+      
+      public Mark() {
+         markable_name = new String("");
+         feature_name = new String("");
+         path = new String("");
+         value = new String("");
+         nrme = null;
+      }
+   }
+   
+   private IProject project;
     
     private static final String DELIM = ",";
 
@@ -61,461 +61,461 @@ public class MarkingData {
     // Ordered map of fully-pathed application model elements and an ordered map of associated feature/value pairs
     private LinkedHashMap<String, LinkedHashMap<String,Mark>> markingsMap;
     
-	public MarkingData(IProject project) {
-		this.project = project;
-	
-		// Read in the feature map
-		populateFeatures();
-		
-		// Read in the markings
-		populateMarkings();
-	}
+   public MarkingData(IProject project) {
+      this.project = project;
+   
+      // Read in the feature map
+      populateFeatures();
+      
+      // Read in the markings
+      populateMarkings();
+   }
 
-	// Read the feature data from the file on disk.  Populate it into an
-	// internal data structure.
-	private void populateFeatures() {
-		featureMap = new HashMap<String, Vector<String>>();
-		Scanner inFile = new Scanner("");
-		
-		try {
-			inFile = new Scanner(new FileReader(project.getLocation().toString() + FEATURE_FILE));
-			inFile.useDelimiter(",|\\r|\\n");
-		} catch (FileNotFoundException fnfe) {
-			// With the change to add the marking listener the data may be attempted to be loaded on a 
-			// project without the .mark files.  This may be fine as not all projects use this style of
-			// marking.  So we don't do anything when the file is not found.
-		}
-		
-		while ( inFile.hasNext() ) {
-			String elementType = inFile.next().trim();
-			if ( elementType.startsWith("#") || elementType.isEmpty() ) {
-				inFile.nextLine().trim();  // Throw away rest of line in case there are delimiters in the comment
-				continue; 
-			}
-			
-			String featureName = inFile.next().trim();
-			Vector<String> list;
-			
-			if ( featureMap.containsKey(elementType) ) {
-				// The element type has already been seen, add the feature to the list
-				list = featureMap.get(elementType);
-			} else {
-				// Element Type has not been seen yet
-				list = new Vector<String>();
-				featureMap.put(elementType, list);
-			}
-			list.add(featureName);
-		}
-		
-		inFile.close();
-	}
+   // Read the feature data from the file on disk.  Populate it into an
+   // internal data structure.
+   private void populateFeatures() {
+      featureMap = new HashMap<String, Vector<String>>();
+      Scanner inFile = new Scanner("");
+      
+      try {
+         inFile = new Scanner(new FileReader(project.getLocation().toString() + FEATURE_FILE));
+         inFile.useDelimiter(",|\\r|\\n");
+      } catch (FileNotFoundException fnfe) {
+         // With the change to add the marking listener the data may be attempted to be loaded on a 
+         // project without the .mark files.  This may be fine as not all projects use this style of
+         // marking.  So we don't do anything when the file is not found.
+      }
+      
+      while ( inFile.hasNext() ) {
+         String elementType = inFile.next().trim();
+         if ( elementType.startsWith("#") || elementType.isEmpty() ) {
+            inFile.nextLine().trim();  // Throw away rest of line in case there are delimiters in the comment
+            continue; 
+         }
+         
+         String featureName = inFile.next().trim();
+         Vector<String> list;
+         
+         if ( featureMap.containsKey(elementType) ) {
+            // The element type has already been seen, add the feature to the list
+            list = featureMap.get(elementType);
+         } else {
+            // Element Type has not been seen yet
+            list = new Vector<String>();
+            featureMap.put(elementType, list);
+         }
+         list.add(featureName);
+      }
+      
+      inFile.close();
+   }
 
-	// Read the application marking data from the file on disk.  Populate it into an
-	// internal data structure.
-	private void populateMarkings() {
-		markingsMap = new LinkedHashMap<String, LinkedHashMap<String,Mark>>();
-		Scanner inFile = new Scanner("");
-		
-		try {
-			inFile = new Scanner(new FileReader(project.getLocation().toString() + MARKINGS_FILE));
-			inFile.useDelimiter(",|\\r|\\n");
-		} catch (FileNotFoundException fnfe) {
-			// With the change to add the marking listener the data may be attempted to be loaded on a 
-			// project without the .mark files.  This may be fine as not all projects use this style of
-			// marking.  So we don't do anything when the file is not found.
-		}
-		
-		while ( inFile.hasNext() ) {
-			String modelElement = inFile.next().trim();
-			String featureName = inFile.next().trim();
-			String elementType = inFile.next().trim();
-			String featureValue = inFile.nextLine().trim();
-			featureValue = featureValue.replaceFirst(",", "");
-			updateFeature(modelElement, featureName, featureValue, elementType);
-		}
-		
-		inFile.close();
-	}
+   // Read the application marking data from the file on disk.  Populate it into an
+   // internal data structure.
+   private void populateMarkings() {
+      markingsMap = new LinkedHashMap<String, LinkedHashMap<String,Mark>>();
+      Scanner inFile = new Scanner("");
+      
+      try {
+         inFile = new Scanner(new FileReader(project.getLocation().toString() + MARKINGS_FILE));
+         inFile.useDelimiter(",|\\r|\\n");
+      } catch (FileNotFoundException fnfe) {
+         // With the change to add the marking listener the data may be attempted to be loaded on a 
+         // project without the .mark files.  This may be fine as not all projects use this style of
+         // marking.  So we don't do anything when the file is not found.
+      }
+      
+      while ( inFile.hasNext() ) {
+         String modelElement = inFile.next().trim();
+         String featureName = inFile.next().trim();
+         String elementType = inFile.next().trim();
+         String featureValue = inFile.nextLine().trim();
+         featureValue = featureValue.replaceFirst(",", "");
+         updateFeature(modelElement, featureName, featureValue, elementType);
+      }
+      
+      inFile.close();
+   }
 
-	/**
-	 * Determine if the features are associated with valid OOA element types.
-	 *
-	 * @return String - An error message if issues were found, otherwise empty string
-	 */
-	public String validateFeatures() {
-		Set<String> featureSet = featureMap.keySet();
-		Iterator<String> featureSetIter = featureSet.iterator();
-		String invalidElements = "";
-		String msg = "";
-		
-		while (featureSetIter.hasNext()) {
-			String ooaClassName = featureSetIter.next();
-			ooaClassName = ooaClassName.replaceAll(" ", "");
-			try {
-				Class.forName(CorePlugin.getDefault().getBundle().getSymbolicName() + "." + ooaClassName + "_c");
-			} catch (ClassNotFoundException e) {
-				invalidElements = invalidElements + ooaClassName + "\n";
-			}
-		}
-		
-		if ( !invalidElements.isEmpty() ) {
-			msg = "The features marking data contains the following invalid element types. You must\n" + 
-					"correct these errors in order to edit application marks: \n\n" + invalidElements;
-		}
-		
-		if ( msg.isEmpty() ) {
-			if ( featureMap.isEmpty() ) {
-				msg = "The gen/features.mark file does not contain any model compiler features. You must\n" +
-					  "specify valid features to proceed.  For more information see the documentation at:\n\n" + 
-					  "Help > BridgePoint UML Suite Help > Reference > User Interface > Marking Editor.\n";
-			}
-		}
-		return msg;
-	}
-	
-	/**
-	 * Modify the user-specified value for an application mark
-	 *
-	 * @param modelElement string path of an instance in the application model delimited by ::
-	 * @param featureName string feature name
-	 * @param newValue string value to assign to the feature
-	 * @param elemType the xtUML model element type name
-	 */
-	public void updateFeature(String modelElement, String featureName, String newValue, String elemType) {
-		LinkedHashMap<String,Mark> markList;
+   /**
+    * Determine if the features are associated with valid OOA element types.
+    *
+    * @return String - An error message if issues were found, otherwise empty string
+    */
+   public String validateFeatures() {
+      Set<String> featureSet = featureMap.keySet();
+      Iterator<String> featureSetIter = featureSet.iterator();
+      String invalidElements = "";
+      String msg = "";
+      
+      while (featureSetIter.hasNext()) {
+         String ooaClassName = featureSetIter.next();
+         ooaClassName = ooaClassName.replaceAll(" ", "");
+         try {
+            Class.forName(CorePlugin.getDefault().getBundle().getSymbolicName() + "." + ooaClassName + "_c");
+         } catch (ClassNotFoundException e) {
+            invalidElements = invalidElements + ooaClassName + "\n";
+         }
+      }
+      
+      if ( !invalidElements.isEmpty() ) {
+         msg = "The features marking data contains the following invalid element types. You must\n" + 
+               "correct these errors in order to edit application marks: \n\n" + invalidElements;
+      }
+      
+      if ( msg.isEmpty() ) {
+         if ( featureMap.isEmpty() ) {
+            msg = "The gen/features.mark file does not contain any model compiler features. You must\n" +
+                 "specify valid features to proceed.  For more information see the documentation at:\n\n" + 
+                 "Help > BridgePoint UML Suite Help > Reference > User Interface > Marking Editor.\n";
+         }
+      }
+      return msg;
+   }
+   
+   /**
+    * Modify the user-specified value for an application mark
+    *
+    * @param modelElement string path of an instance in the application model delimited by ::
+    * @param featureName string feature name
+    * @param newValue string value to assign to the feature
+    * @param elemType the xtUML model element type name
+    */
+   public void updateFeature(String modelElement, String featureName, String newValue, String elemType) {
+      LinkedHashMap<String,Mark> markList;
 
-		if ( markingsMap.containsKey(modelElement) ) {
-			// The model element has already been seen, add the feature to the list
-			markList = markingsMap.get(modelElement);
-		} else {
-			// Element Type has not been seen yet
-			markList = new LinkedHashMap<String,Mark>();
-			markingsMap.put(modelElement, markList);
-		}
-		Mark mark = new Mark();
-		mark.markable_name = elemType;
-		mark.feature_name = featureName;
-		mark.path = modelElement;
-		mark.value = newValue;
-		mark.nrme = MarkingData.getNRMEForMark(modelElement, elemType, this.project);
-		markList.put(getCombinedRef(featureName, elemType), mark);
-	}
+      if ( markingsMap.containsKey(modelElement) ) {
+         // The model element has already been seen, add the feature to the list
+         markList = markingsMap.get(modelElement);
+      } else {
+         // Element Type has not been seen yet
+         markList = new LinkedHashMap<String,Mark>();
+         markingsMap.put(modelElement, markList);
+      }
+      Mark mark = new Mark();
+      mark.markable_name = elemType;
+      mark.feature_name = featureName;
+      mark.path = modelElement;
+      mark.value = newValue;
+      mark.nrme = MarkingData.getNRMEForMark(modelElement, elemType, this.project);
+      markList.put(getCombinedRef(featureName, elemType), mark);
+   }
 
-	/**
-	 * A mark is uniquely identified by its path and the combined referential 
-	 * composed of the feature name and markable name.  This function is used to 
-	 * "make" the combined referential string for the internal data structure used
-	 * to store and order the marks.
-	 */
-	public static String getCombinedRef(String f, String m) {
-		return f+"###"+m;
-	}
-	
-	/**
-	 * Iterate through all the marks and update model path keys. 
-	 *
-	 * @return Flag indicating if the markings had to be updated or not 
-	 */
-	public boolean recalculatePathKeys() {
-		LinkedHashMap<String,Mark> newMarkList;
-		LinkedHashMap<String, LinkedHashMap<String,Mark>> newMarkingsMap = new LinkedHashMap<String, LinkedHashMap<String,Mark>>();
-		boolean marksUpdated = false;
-		
-		for (Map.Entry<String, LinkedHashMap<String,Mark>> elementEntry : markingsMap.entrySet()) {
-			Set<Map.Entry<String, Mark>> featureEntrySet = elementEntry.getValue().entrySet();
+   /**
+    * A mark is uniquely identified by its path and the combined referential 
+    * composed of the feature name and markable name.  This function is used to 
+    * "make" the combined referential string for the internal data structure used
+    * to store and order the marks.
+    */
+   public static String getCombinedRef(String f, String m) {
+      return f+"###"+m;
+   }
+   
+   /**
+    * Iterate through all the marks and update model path keys. 
+    *
+    * @return Flag indicating if the markings had to be updated or not 
+    */
+   public boolean recalculatePathKeys() {
+      LinkedHashMap<String,Mark> newMarkList;
+      LinkedHashMap<String, LinkedHashMap<String,Mark>> newMarkingsMap = new LinkedHashMap<String, LinkedHashMap<String,Mark>>();
+      boolean marksUpdated = false;
+      
+      for (Map.Entry<String, LinkedHashMap<String,Mark>> elementEntry : markingsMap.entrySet()) {
+         Set<Map.Entry<String, Mark>> featureEntrySet = elementEntry.getValue().entrySet();
 
-			// Run a path check on the first mark in the set.  If it's OK, then all the marks in this set
-			// are OK and we skip further processing.  If it's not OK, we must iterate through all the marks
-			// for this model element and update them.
-			Map.Entry<String, Mark> firstfeatureEntry = featureEntrySet.iterator().next(); 
-			// Use the mark's nrme to get the updated path and see if it matches elementEntry.getKey()
-			String newPath = MarkingData.getPathkey((NonRootModelElement) firstfeatureEntry.getValue().nrme, project);
-			String currentPath = elementEntry.getKey();
-			if ((newPath == null) || newPath.isEmpty()) {
-				// A container for the marked element must have been deleted, remove the mark
-				marksUpdated = true;
-				continue;
-			} else if ( newPath.equals(currentPath)) {
-				// This element's path is not affected, short circuit and copy across the whole 
-				// mark list to newMarkingsMap and move on
-				newMarkingsMap.put(newPath, elementEntry.getValue());
-				continue;
-			} else {
-				// This element's path _is_ changed, iterate through each mark and update the path 
-				// in the mark and store under the new path in the newMarkingsMap
-				marksUpdated = true;
-				newMarkList = new LinkedHashMap<String,Mark>();
-				newMarkingsMap.put(newPath, newMarkList);
-						
-				for ( Map.Entry<String, Mark> featureEntry : featureEntrySet) {
-					Mark origMark = featureEntry.getValue();
-					Mark mark = new Mark(); 
-					mark.markable_name = origMark.markable_name; 
-					mark.feature_name = origMark.feature_name; 
-					mark.path = newPath; 
-					mark.value = origMark.value; 
-					mark.nrme = origMark.nrme; 
-					newMarkList.put(featureEntry.getKey(), mark);
-				}
-			}
-		}
-		
-		// Use the newly updated map of markings
-		if (marksUpdated) {
-			markingsMap = newMarkingsMap;
-		}
-		
-		return marksUpdated;
-	}
+         // Run a path check on the first mark in the set.  If it's OK, then all the marks in this set
+         // are OK and we skip further processing.  If it's not OK, we must iterate through all the marks
+         // for this model element and update them.
+         Map.Entry<String, Mark> firstfeatureEntry = featureEntrySet.iterator().next(); 
+         // Use the mark's nrme to get the updated path and see if it matches elementEntry.getKey()
+         String newPath = MarkingData.getPathkey((NonRootModelElement) firstfeatureEntry.getValue().nrme, project);
+         String currentPath = elementEntry.getKey();
+         if ((newPath == null) || newPath.isEmpty()) {
+            // A container for the marked element must have been deleted, remove the mark
+            marksUpdated = true;
+            continue;
+         } else if ( newPath.equals(currentPath)) {
+            // This element's path is not affected, short circuit and copy across the whole 
+            // mark list to newMarkingsMap and move on
+            newMarkingsMap.put(newPath, elementEntry.getValue());
+            continue;
+         } else {
+            // This element's path _is_ changed, iterate through each mark and update the path 
+            // in the mark and store under the new path in the newMarkingsMap
+            marksUpdated = true;
+            newMarkList = new LinkedHashMap<String,Mark>();
+            newMarkingsMap.put(newPath, newMarkList);
+                  
+            for ( Map.Entry<String, Mark> featureEntry : featureEntrySet) {
+               Mark origMark = featureEntry.getValue();
+               Mark mark = new Mark(); 
+               mark.markable_name = origMark.markable_name; 
+               mark.feature_name = origMark.feature_name; 
+               mark.path = newPath; 
+               mark.value = origMark.value; 
+               mark.nrme = origMark.nrme; 
+               newMarkList.put(featureEntry.getKey(), mark);
+            }
+         }
+      }
+      
+      // Use the newly updated map of markings
+      if (marksUpdated) {
+         markingsMap = newMarkingsMap;
+      }
+      
+      return marksUpdated;
+   }
 
-	public boolean updateClassNameData(String newAttributeValue, String oldAttributeValue)
-	{
-		LinkedHashMap<String, LinkedHashMap<String,Mark>> newMarkingsMap = new LinkedHashMap<String, LinkedHashMap<String,Mark>>();
-		boolean marksUpdated = false;
-		
-		for (Map.Entry<String, LinkedHashMap<String,Mark>> elementEntry : markingsMap.entrySet()) {
-			LinkedHashMap<String,Mark> newMarkList = new LinkedHashMap<String,Mark>();
-			for ( Map.Entry<String, Mark> featureEntry : elementEntry.getValue().entrySet() ) { 
-				if ( featureEntry.getValue().path.endsWith(oldAttributeValue) ) {
-					String newPath = elementEntry.getKey().substring(0, elementEntry.getKey().lastIndexOf(oldAttributeValue)).concat(newAttributeValue);
-					marksUpdated = true;
-					Mark origMark = featureEntry.getValue();
-					Mark mark = new Mark(); 
-					mark.markable_name = origMark.markable_name; 
-					mark.feature_name = origMark.feature_name; 
-					mark.path = newPath; 
-					mark.value = origMark.value; 
-					mark.nrme = origMark.nrme; 
-					newMarkList.put(newPath, mark);
-				} else {
-					// Unchanged entry
-					newMarkList.put(featureEntry.getKey(), featureEntry.getValue());
-				}
-			}
-			newMarkingsMap.put(elementEntry.getKey(), newMarkList);
-		}
-		// Use the newly updated map of markings
-		if (marksUpdated) {
-			markingsMap = newMarkingsMap;
-		}
-		return marksUpdated;
-	}
+   public boolean updateClassNameData(String newAttributeValue, String oldAttributeValue)
+   {
+      LinkedHashMap<String, LinkedHashMap<String,Mark>> newMarkingsMap = new LinkedHashMap<String, LinkedHashMap<String,Mark>>();
+      boolean marksUpdated = false;
+      
+      for (Map.Entry<String, LinkedHashMap<String,Mark>> elementEntry : markingsMap.entrySet()) {
+         LinkedHashMap<String,Mark> newMarkList = new LinkedHashMap<String,Mark>();
+         for ( Map.Entry<String, Mark> featureEntry : elementEntry.getValue().entrySet() ) { 
+            if ( featureEntry.getValue().path.endsWith(oldAttributeValue) ) {
+               String newPath = elementEntry.getKey().substring(0, elementEntry.getKey().lastIndexOf(oldAttributeValue)).concat(newAttributeValue);
+               marksUpdated = true;
+               Mark origMark = featureEntry.getValue();
+               Mark mark = new Mark(); 
+               mark.markable_name = origMark.markable_name; 
+               mark.feature_name = origMark.feature_name; 
+               mark.path = newPath; 
+               mark.value = origMark.value; 
+               mark.nrme = origMark.nrme; 
+               newMarkList.put(newPath, mark);
+            } else {
+               // Unchanged entry
+               newMarkList.put(featureEntry.getKey(), featureEntry.getValue());
+            }
+         }
+         newMarkingsMap.put(elementEntry.getKey(), newMarkList);
+      }
+      // Use the newly updated map of markings
+      if (marksUpdated) {
+         markingsMap = newMarkingsMap;
+      }
+      return marksUpdated;
+   }
 
-	/**
-	 * Write the modified application marking data to disk
-	 */
-	public void persist() {
-		try {
-			FileOutputStream fout = new FileOutputStream(project.getLocation().toString() + MARKINGS_FILE);
-			PrintStream stream = new PrintStream(fout);
-			
-			// Persist the markings
-			for (Map.Entry<String, LinkedHashMap<String,Mark>> elementEntry : markingsMap.entrySet()) {
-				for ( Map.Entry<String, Mark> featureEntry : elementEntry.getValue().entrySet()) {
-					if ( ! featureEntry.getValue().value.isEmpty() ) {
-						stream.println(featureEntry.getValue().path + DELIM + featureEntry.getValue().feature_name + DELIM + featureEntry.getValue().markable_name + DELIM + featureEntry.getValue().value);
-					}
-				}
-			}
-			fout.close();
-		} catch (IOException e) {
-			CorePlugin.logError("Error persisting to " + MARKINGS_FILE, e);
-		}        
-	}
+   /**
+    * Write the modified application marking data to disk
+    */
+   public void persist() {
+      try {
+         FileOutputStream fout = new FileOutputStream(project.getLocation().toString() + MARKINGS_FILE);
+         PrintStream stream = new PrintStream(fout);
+         
+         // Persist the markings
+         for (Map.Entry<String, LinkedHashMap<String,Mark>> elementEntry : markingsMap.entrySet()) {
+            for ( Map.Entry<String, Mark> featureEntry : elementEntry.getValue().entrySet()) {
+               if ( ! featureEntry.getValue().value.isEmpty() ) {
+                  stream.println(featureEntry.getValue().path + DELIM + featureEntry.getValue().feature_name + DELIM + featureEntry.getValue().markable_name + DELIM + featureEntry.getValue().value);
+               }
+            }
+         }
+         fout.close();
+      } catch (IOException e) {
+         CorePlugin.logError("Error persisting to " + MARKINGS_FILE, e);
+      }        
+   }
 
-	/**
-	 * The feature marking file contains markable elements and the available
-	 * features.  This returns a collection of the markable elements specified.
-	 *
-	 * @return Array of model element types that have features that can be marked
-	 */
-	public String[] getMarkables() {
-		return featureMap.keySet().stream().toArray(String[]::new);
-	}
+   /**
+    * The feature marking file contains markable elements and the available
+    * features.  This returns a collection of the markable elements specified.
+    *
+    * @return Array of model element types that have features that can be marked
+    */
+   public String[] getMarkables() {
+      return featureMap.keySet().stream().toArray(String[]::new);
+   }
 
-	/**
-	 * Returns the names of features associated with a given element type
-	 *
-	 * @param elementType string name of an OOA element type (e.g. Model Class, Component)
-	 * @return Vector<String> collection of feature names
-	 */
-	public Vector<String> getFeatures(String elementType) {
-		return featureMap.get(elementType);
-	}
+   /**
+    * Returns the names of features associated with a given element type
+    *
+    * @param elementType string name of an OOA element type (e.g. Model Class, Component)
+    * @return Vector<String> collection of feature names
+    */
+   public Vector<String> getFeatures(String elementType) {
+      return featureMap.get(elementType);
+   }
 
-	/**
-	 * Returns an ordered collection of marks for a given 
-	 * application model instance.  Makes sure we return a clean/unique set
-	 * of marks that avoids path collisions by using the element type to resolve
-	 * ambiguities.
-	 *
-	 * @param modelElement string path of an instance in the application model delimited by ::
-	 * @param elemType the xtUML model element type name
-	 * @return LinkedHashMap<String,ValueSet> ordered collection of feature/value pairs
-	 */
-	public LinkedHashMap<String,Mark> getMarks(String modelElement, String elemType) {
-		LinkedHashMap<String,Mark> uncleanMarks = markingsMap.get(modelElement);
-		LinkedHashMap<String,Mark> uniqueMarks = new LinkedHashMap<String,Mark>();
-		
-		if ( uncleanMarks == null ) {
-			return null;
-		} else {
-			for (Map.Entry<String, Mark> entry : uncleanMarks.entrySet())
-			{
-				if ( entry.getValue().markable_name.equals(elemType) ) {
-					uniqueMarks.put(entry.getKey(), entry.getValue());
-				}
-			}
-		}
-		return uniqueMarks;
-	}
+   /**
+    * Returns an ordered collection of marks for a given 
+    * application model instance.  Makes sure we return a clean/unique set
+    * of marks that avoids path collisions by using the element type to resolve
+    * ambiguities.
+    *
+    * @param modelElement string path of an instance in the application model delimited by ::
+    * @param elemType the xtUML model element type name
+    * @return LinkedHashMap<String,ValueSet> ordered collection of feature/value pairs
+    */
+   public LinkedHashMap<String,Mark> getMarks(String modelElement, String elemType) {
+      LinkedHashMap<String,Mark> uncleanMarks = markingsMap.get(modelElement);
+      LinkedHashMap<String,Mark> uniqueMarks = new LinkedHashMap<String,Mark>();
+      
+      if ( uncleanMarks == null ) {
+         return null;
+      } else {
+         for (Map.Entry<String, Mark> entry : uncleanMarks.entrySet())
+         {
+            if ( entry.getValue().markable_name.equals(elemType) ) {
+               uniqueMarks.put(entry.getKey(), entry.getValue());
+            }
+         }
+      }
+      return uniqueMarks;
+   }
 
-	/**
-	 * Returns an collection of marks for a given application model instance using 
-	 * a NonRootModelElement to find matches. 
-	 *
-	 * @param nrme A NonRootModelElement instance to match against 
-	 * @return LinkedHashMap<String,Mark> collection of feature/value pairs
-	 */
-	public LinkedHashMap<String,Mark> getMarks(NonRootModelElement nrme) {
-		LinkedHashMap<String,Mark> marks = new LinkedHashMap<String,Mark>();
-		
-		for (Map.Entry<String, LinkedHashMap<String,Mark>> entry : markingsMap.entrySet())
-		{
-			marks = entry.getValue();
-			for (Map.Entry<String, Mark> markEntry : marks.entrySet())
-			{
-				if ( markEntry.getValue().nrme == nrme ) {
-					return getMarks(markEntry.getKey(), markEntry.getValue().markable_name);
-				}
-			}
-		}
-		return null;
-	}
+   /**
+    * Returns an collection of marks for a given application model instance using 
+    * a NonRootModelElement to find matches. 
+    *
+    * @param nrme A NonRootModelElement instance to match against 
+    * @return LinkedHashMap<String,Mark> collection of feature/value pairs
+    */
+   public LinkedHashMap<String,Mark> getMarks(NonRootModelElement nrme) {
+      LinkedHashMap<String,Mark> marks = new LinkedHashMap<String,Mark>();
+      
+      for (Map.Entry<String, LinkedHashMap<String,Mark>> entry : markingsMap.entrySet())
+      {
+         marks = entry.getValue();
+         for (Map.Entry<String, Mark> markEntry : marks.entrySet())
+         {
+            if ( markEntry.getValue().nrme == nrme ) {
+               return getMarks(markEntry.getKey(), markEntry.getValue().markable_name);
+            }
+         }
+      }
+      return null;
+   }
 
-	public static String getPathkey(NonRootModelElement inst, IProject project) {
-		String signature = new String("");
-		if (inst == null) { return ""; }
-		String pathkey = ((NonRootModelElement) inst).getPath();
-		
-		// If we're dealing with anything other than a package under the system and the path comes back as 
-		// just the element name, this means the instance is being deleted and does not currently have a 
-		// valid path.
-		if ( !(inst instanceof Package_c) ||
-				((inst instanceof Package_c) && ( SystemModel_c.getOneS_SYSOnR1401((Package_c)inst) == null))) {
-			if (pathkey.equals(inst.getName())) {
-				return "";
-			}
-		}
+   public static String getPathkey(NonRootModelElement inst, IProject project) {
+      String signature = new String("");
+      if (inst == null) { return ""; }
+      String pathkey = ((NonRootModelElement) inst).getPath();
+      
+      // If we're dealing with anything other than a package under the system and the path comes back as 
+      // just the element name, this means the instance is being deleted and does not currently have a 
+      // valid path.
+      if ( !(inst instanceof Package_c) ||
+            ((inst instanceof Package_c) && ( SystemModel_c.getOneS_SYSOnR1401((Package_c)inst) == null))) {
+         if (pathkey.equals(inst.getName())) {
+            return "";
+         }
+      }
 
-		// If the instance requires a full signature, replace the last segment which
-		// is the name with the full signature
-		if (inst instanceof Function_c) {
-			signature = ((Function_c) inst).Getsignature(1);
-		} else if (inst instanceof Operation_c) {
-			signature = ((Operation_c) inst).Getsignature(1);
-		} else if (inst instanceof InterfaceOperation_c) {
-			signature = ((InterfaceOperation_c) inst).Getsignature(1);
-		} else if (inst instanceof InterfaceSignal_c) {
-			signature = ((InterfaceSignal_c) inst).Getsignature(1);
-		} else if (inst instanceof TerminatorService_c) {
-			signature = ((TerminatorService_c) inst).Getsignature(1);
-		}
-		
-		if (!signature.isEmpty()) {
-			signature = signature.replaceAll(", ", " ");
-			String[] pathPieces = pathkey.split("::");
-			String updatedPath = new String("");
-			for (int i=0; i<pathPieces.length-1; ++i) {
-				updatedPath = updatedPath.concat(pathPieces[i] + "::");
-			}
-			updatedPath = updatedPath.concat(signature);
-			pathkey = updatedPath;
-		}
+      // If the instance requires a full signature, replace the last segment which
+      // is the name with the full signature
+      if (inst instanceof Function_c) {
+         signature = ((Function_c) inst).Getsignature(1);
+      } else if (inst instanceof Operation_c) {
+         signature = ((Operation_c) inst).Getsignature(1);
+      } else if (inst instanceof InterfaceOperation_c) {
+         signature = ((InterfaceOperation_c) inst).Getsignature(1);
+      } else if (inst instanceof InterfaceSignal_c) {
+         signature = ((InterfaceSignal_c) inst).Getsignature(1);
+      } else if (inst instanceof TerminatorService_c) {
+         signature = ((TerminatorService_c) inst).Getsignature(1);
+      }
+      
+      if (!signature.isEmpty()) {
+         signature = signature.replaceAll(", ", " ");
+         String[] pathPieces = pathkey.split("::");
+         String updatedPath = new String("");
+         for (int i=0; i<pathPieces.length-1; ++i) {
+            updatedPath = updatedPath.concat(pathPieces[i] + "::");
+         }
+         updatedPath = updatedPath.concat(signature);
+         pathkey = updatedPath;
+      }
 
-		pathkey = pathkey.replaceFirst(project.getName() + "::", "");
-		return pathkey;
-	}
-	
-	/*
-	 * Gather and return a collection of all the application model instances of a requested type
-	 * (i.e. OOA metamodel class like Attribute, Model Class, Function, etc) from all the model roots
-	 * in the given project.
-	 */
-	public static ArrayList<Object> getInstancesForType(String elementType, IProject project) {
-		ArrayList<Object> allInstances = new ArrayList<Object>();
+      pathkey = pathkey.replaceFirst(project.getName() + "::", "");
+      return pathkey;
+   }
+   
+   /*
+    * Gather and return a collection of all the application model instances of a requested type
+    * (i.e. OOA metamodel class like Attribute, Model Class, Function, etc) from all the model roots
+    * in the given project.
+    */
+   public static ArrayList<Object> getInstancesForType(String elementType, IProject project) {
+      ArrayList<Object> allInstances = new ArrayList<Object>();
 
-		try {
-			String ooaClassName = elementType.trim();
-			ooaClassName = ooaClassName.replaceAll(" ", "");
-			// Get the Class object for the metamodel class with the specified name
-			Class<?> clazz = Class.forName(CorePlugin.getDefault().getBundle().getSymbolicName() + "." + ooaClassName + "_c");
+      try {
+         String ooaClassName = elementType.trim();
+         ooaClassName = ooaClassName.replaceAll(" ", "");
+         // Get the Class object for the metamodel class with the specified name
+         Class<?> clazz = Class.forName(CorePlugin.getDefault().getBundle().getSymbolicName() + "." + ooaClassName + "_c");
 
-			ModelRoot[] roots = Ooaofooa.getInstancesUnderSystem(project.getName());
-			// This Java reflection call helps invoke a method like this:
-			// ModelClass_c[] mcs = ModelClass_c.ModelClassInstances(modelRoot);
-			// So the loop here finds all instances of a given OOAofOOA class in
-			// a project.
-			Method instancesMethod = clazz.getMethod(ooaClassName + "Instances", ModelRoot.class);
-			for (ModelRoot modelroot : roots) {
-				Object[] instances = (Object[]) instancesMethod.invoke(null, modelroot);
-				Collections.addAll(allInstances, instances);
-			}
-		} catch (ClassNotFoundException | NoSuchMethodException | NullPointerException | SecurityException |
-				IllegalAccessException | IllegalArgumentException | InvocationTargetException | 
-				ExceptionInInitializerError e) {
-			CorePlugin.logError(e.toString(), e);
-		}
-		return allInstances;
-	}
-	
-	public static NonRootModelElement getNRMEForMark(String path, String elementType, IProject project) {
-		ArrayList<Object> instances = MarkingData.getInstancesForType(elementType, project);
-		for (Object candidate: instances) {
-			String candidatePath = MarkingData.getPathkey((NonRootModelElement) candidate, project);
-			if ( path.equals(candidatePath) ) {
-				return (NonRootModelElement) candidate;
-			}
-		}
-		return null;
-	}
-	
-	/**
-	 * Update the keyletter value contained in the mark.
-	 * @param newAttributeValue - the new keyletter
-	 * @param oldAttributeValue - the old keyletter
-	 * @return Indicates if the marking data needs to be persisted.
-	 */
-	public boolean updateKeyletterData(String newAttributeValue, String oldAttributeValue)
-	{
-		LinkedHashMap<String, LinkedHashMap<String,Mark>> newMarkingsMap = new LinkedHashMap<String, LinkedHashMap<String,Mark>>();
-		boolean marksUpdated = false;
-		
-		for (Map.Entry<String, LinkedHashMap<String,Mark>> elementEntry : markingsMap.entrySet()) {
-			LinkedHashMap<String,Mark> newMarkList = new LinkedHashMap<String,Mark>();
-			for ( Map.Entry<String, Mark> featureEntry : elementEntry.getValue().entrySet() ) { 
-				if ( featureEntry.getValue().value.regionMatches(1, oldAttributeValue, 0, oldAttributeValue.length()) ) {
-					marksUpdated = true;
-					Mark origMark = featureEntry.getValue();
-					Mark mark = new Mark(); 
-					mark.markable_name = origMark.markable_name; 
-					mark.feature_name = origMark.feature_name; 
-					mark.path = origMark.path; 
-					mark.value = "\"" + newAttributeValue + "\""; 
-					mark.nrme = origMark.nrme; 
-					newMarkList.put(featureEntry.getKey(), mark);
-				} else {
-					// Unchanged entry
-					newMarkList.put(featureEntry.getKey(), featureEntry.getValue());
-				}
-			}
-			newMarkingsMap.put(elementEntry.getKey(), newMarkList);
-		}
-		// Use the newly updated map of markings
-		if (marksUpdated) {
-			markingsMap = newMarkingsMap;
-		}
-		return marksUpdated;
-	}
-	
+         ModelRoot[] roots = Ooaofooa.getInstancesUnderSystem(project.getName());
+         // This Java reflection call helps invoke a method like this:
+         // ModelClass_c[] mcs = ModelClass_c.ModelClassInstances(modelRoot);
+         // So the loop here finds all instances of a given OOAofOOA class in
+         // a project.
+         Method instancesMethod = clazz.getMethod(ooaClassName + "Instances", ModelRoot.class);
+         for (ModelRoot modelroot : roots) {
+            Object[] instances = (Object[]) instancesMethod.invoke(null, modelroot);
+            Collections.addAll(allInstances, instances);
+         }
+      } catch (ClassNotFoundException | NoSuchMethodException | NullPointerException | SecurityException |
+            IllegalAccessException | IllegalArgumentException | InvocationTargetException | 
+            ExceptionInInitializerError e) {
+         CorePlugin.logError(e.toString(), e);
+      }
+      return allInstances;
+   }
+   
+   public static NonRootModelElement getNRMEForMark(String path, String elementType, IProject project) {
+      ArrayList<Object> instances = MarkingData.getInstancesForType(elementType, project);
+      for (Object candidate: instances) {
+         String candidatePath = MarkingData.getPathkey((NonRootModelElement) candidate, project);
+         if ( path.equals(candidatePath) ) {
+            return (NonRootModelElement) candidate;
+         }
+      }
+      return null;
+   }
+   
+   /**
+    * Update the keyletter value contained in the mark.
+    * @param newAttributeValue - the new keyletter
+    * @param oldAttributeValue - the old keyletter
+    * @return Indicates if the marking data needs to be persisted.
+    */
+   public boolean updateKeyletterData(String newAttributeValue, String oldAttributeValue)
+   {
+      LinkedHashMap<String, LinkedHashMap<String,Mark>> newMarkingsMap = new LinkedHashMap<String, LinkedHashMap<String,Mark>>();
+      boolean marksUpdated = false;
+      
+      for (Map.Entry<String, LinkedHashMap<String,Mark>> elementEntry : markingsMap.entrySet()) {
+         LinkedHashMap<String,Mark> newMarkList = new LinkedHashMap<String,Mark>();
+         for ( Map.Entry<String, Mark> featureEntry : elementEntry.getValue().entrySet() ) { 
+            if ( featureEntry.getValue().value.regionMatches(1, oldAttributeValue, 0, oldAttributeValue.length()) ) {
+               marksUpdated = true;
+               Mark origMark = featureEntry.getValue();
+               Mark mark = new Mark(); 
+               mark.markable_name = origMark.markable_name; 
+               mark.feature_name = origMark.feature_name; 
+               mark.path = origMark.path; 
+               mark.value = "\"" + newAttributeValue + "\""; 
+               mark.nrme = origMark.nrme; 
+               newMarkList.put(featureEntry.getKey(), mark);
+            } else {
+               // Unchanged entry
+               newMarkList.put(featureEntry.getKey(), featureEntry.getValue());
+            }
+         }
+         newMarkingsMap.put(elementEntry.getKey(), newMarkList);
+      }
+      // Use the newly updated map of markings
+      if (marksUpdated) {
+         markingsMap = newMarkingsMap;
+      }
+      return marksUpdated;
+   }
+   
 }

--- a/src/org.xtuml.bp.ui.marking/src/org/xtuml/bp/ui/marking/MarkingData.java
+++ b/src/org.xtuml.bp.ui.marking/src/org/xtuml/bp/ui/marking/MarkingData.java
@@ -326,6 +326,7 @@ public class MarkingData {
 
    /**
     * Check the value data, contained in the mark, for change and update on change.
+    * @param nrmeOfChange - the NRME obtained from the transaction
     * @param newAttributeValue - the new value
     * @param oldAttributeValue - the old value
     * @return Indicates if the marking data needs to be persisted.

--- a/src/org.xtuml.bp.ui.marking/src/org/xtuml/bp/ui/marking/MarkingData.java
+++ b/src/org.xtuml.bp.ui.marking/src/org/xtuml/bp/ui/marking/MarkingData.java
@@ -267,7 +267,8 @@ public class MarkingData {
 		
 		return marksUpdated;
 	}
-	public boolean updateNameData(String newAttributeValue, String oldAttributeValue, String attributeName)
+
+	public boolean updateClassNameData(String newAttributeValue, String oldAttributeValue)
 	{
 		LinkedHashMap<String, LinkedHashMap<String,Mark>> newMarkingsMap = new LinkedHashMap<String, LinkedHashMap<String,Mark>>();
 		boolean marksUpdated = false;


### PR DESCRIPTION
This should improve the mark updating, but doesn't completely solve the issue.

I think my testing exposed the issue more, because I was launching the debugger BridgePoint and editing the model right away. It seems to not happen as easily if you wait a little while.

The NRME check in the Mark.value data update handling assumes that the ElemType matches the value.