### PR TITLE
job #11930 - Added environment variable checks

### DIFF
--- a/doc-bridgepoint/process/Developer Getting Started Guide.md
+++ b/doc-bridgepoint/process/Developer Getting Started Guide.md
@@ -71,7 +71,9 @@ Build Instructions
   git clone https://github.com/"username"/packaging.git ~/git/packaging
   ```
 
-  - Modify ```~/git/bridgepoint/utilities/build/build_configuration.sh``` to account for your local paths. Also adjust the flag to indicate if you want to run all the JUnit tests during build or not.  
+  - There are two ways to configure the build:
+    - Modify ```~/git/bridgepoint/utilities/build/build_configuration.sh``` to account for your local paths. Also adjust the flag to indicate if you want to run all the JUnit tests during build or not.  
+    - Add environment variables to your user environment to override the variables in ```~/git/bridgepoint/utilities/build/build_configuration.sh```. Look inside build_configuration.sh to see which variables you can override.  
 
   - Build BridgePoint:
   ```~/git/bridgepoint/utilities/build/build_and_test_bp.sh```

--- a/utilities/build/build_configuration.sh
+++ b/utilities/build/build_configuration.sh
@@ -1,13 +1,29 @@
 # This script sets up environment variables that
 # are required to prepare a development workspace
 # as well as build such a workspace
-export BP_GIT_DIR=~/git
-# for mac us this install dir
-export bp_install_dir=~/xtuml/BridgePoint.app/Contents/Eclipse/
-# for linux uncomment this line and comment the mac version
-#export bp_install_dir=~/xtuml/BridgePoint
-export WORKSPACE=~/workspace
-export INCLUDE_TESTS=false
+if [ -z $BP_GIT_DIR ]
+then
+  export BP_GIT_DIR=~/git
+fi
+
+if [ -z $bp_install_dir ]
+then
+  # for mac us this install dir
+  export bp_install_dir=~/xtuml/BridgePoint.app/Contents/Eclipse/
+  # for linux uncomment this line and comment the mac version
+  #export bp_install_dir=~/xtuml/BridgePoint
+fi
+
+if [ -z $WORKSPACE ]
+then
+  export WORKSPACE=~/workspace
+fi
+
+if [ -z $INCLUDE_TESTS ]
+then
+  export INCLUDE_TESTS=false
+fi
+
 export XTUML_DEVELOPMENT_REPOSITORY=${BP_GIT_DIR}/bridgepoint
 export XTUML_TEST_MODEL_REPOSITORY=${BP_GIT_DIR}/models/test
 export mcj_path=${XTUML_DEVELOPMENT_REPOSITORY}/src/MC-Java


### PR DESCRIPTION
This allows a developer to set up environment variables, so they don't
have to modify build_configuration.sh.