### PR TITLE
job #9697 - Fix MASL editor file exit

### DIFF
--- a/doc-bridgepoint/notes/9697_closing_masl_editor_int.adoc
+++ b/doc-bridgepoint/notes/9697_closing_masl_editor_int.adoc
@@ -1,0 +1,54 @@
+= Issue closing MASL editor and not saving
+
+xtUML Project Implementation Note
+
+== 1 Abstract
+
+This implementation note describes the fix reported in <<dr-1>>.
+
+== 2 Introduction and Background
+
+User reported that opening a masl text file, modifying it, then closing without
+saving leaves the file in a state, that whenever it is reopened and modified,
+the user is presented with a message that the file is open in another editor.
+
+== 3 Requirements
+
+A file should be able to be opened, modified, and saved or not saved without the
+file being left in a state where any subsequent edits will not view the file as
+already in use.
+
+== 4 Work Required
+
+Ensure the file is properly closed on exit.
+
+== 5 Implementation Comments
+
+This had to do with xtext tracking the "dirty" state of files it's editor 
+opens. The dispose() method in the MASL editor, which inherits the Xtext editor,
+wasn't calling the parent dispose method to properly clean up after itself.
+
+== 6 Unit Test
+
+No unit tests needed.
+
+== 7 User Documentation
+
+== 8 Code Changes
+
+- fork/repository:  lwriemen/bridgepoint
+- branch:  9697-masl-file-lock
+
+----
+ Put the file list here
+----
+
+== 9 Document References
+
+. [[dr-1]] https://support.onefact.net/issues/9697[9697 - Issue closing MASL editor and not saving]
+
+---
+
+This work is licensed under the Creative Commons CC0 License
+
+---

--- a/src/org.xtuml.bp.xtext.masl.parent/org.xtuml.bp.xtext.masl.ui/src/org/xtuml/bp/xtext/masl/ui/document/MaslSnippetEditor.java
+++ b/src/org.xtuml.bp.xtext.masl.parent/org.xtuml.bp.xtext.masl.ui/src/org/xtuml/bp/xtext/masl/ui/document/MaslSnippetEditor.java
@@ -39,10 +39,10 @@ import org.xtuml.bp.xtext.masl.ui.document.MaslDocumentProvider;
 public class MaslSnippetEditor extends XtextEditor {
   @Inject
   private IImageHelper imageHelper;
-  
+
   private Label signatureLabel;
   private IModelChangeListener modelChangeListener;
-  
+
   public MaslSnippetEditor() {
 	  super();
 	  modelChangeListener = new ModelChangeAdapter() {
@@ -75,12 +75,12 @@ public class MaslSnippetEditor extends XtextEditor {
 	  };
 	  Ooaofooa.getDefaultInstance().addModelChangeListener(modelChangeListener);
   }
-  
+
   @Override
   public boolean isSaveAsAllowed() {
     return false;
   }
-  
+
   @Override
   public void createPartControl(final Composite parent) {
     final IEditorInput input = this.getEditorInput();
@@ -125,7 +125,7 @@ public class MaslSnippetEditor extends XtextEditor {
       @Override
       public void elementContentAboutToBeReplaced(final Object element) {
       }
-      
+
       @Override
       public void elementContentReplaced(final Object element) {
         IEditorInput _editorInput = MaslSnippetEditor.this.getEditorInput();
@@ -135,21 +135,21 @@ public class MaslSnippetEditor extends XtextEditor {
           MaslSnippetEditor.this.updateLabelAndVisibleRegion(((MaslDocumentProvider) _documentProvider), ((AbstractModelElementPropertyEditorInput) _editorInput_1));
         }
       }
-      
+
       @Override
       public void elementDeleted(final Object element) {
       }
-      
+
       @Override
       public void elementDirtyStateChanged(final Object element, final boolean isDirty) {
       }
-      
+
       @Override
       public void elementMoved(final Object originalElement, final Object movedElement) {
       }
     });
   }
-  
+
   @Override
   public Image getDefaultImage() {
     Image _xifexpression = null;
@@ -163,9 +163,10 @@ public class MaslSnippetEditor extends XtextEditor {
     }
     return _xifexpression;
   }
-  
+
   @Override
   public void dispose() {
+	  super.dispose();
 	  Ooaofooa.getDefaultInstance().removeModelChangeListener(modelChangeListener);
   }
 


### PR DESCRIPTION
Added call to MaslSnippetEditor.dispose() to call XtextEditor.dispose().