### PR TITLE
11699 association editor

### DIFF
--- a/src/org.xtuml.bp.core/models/org.xtuml.bp.core/ooaofooa/Functions/Context Menu Entry Functions/Context Menu Entry Functions.xtuml
+++ b/src/org.xtuml.bp.core/models/org.xtuml.bp.core/ooaofooa/Functions/Context Menu Entry Functions/Context Menu Entry Functions.xtuml
@@ -8434,13 +8434,16 @@ is_associative = not_empty assoc;
 associative_rel = USER::getCheckbox(default:is_associative, prompt:"Associative", disabled:false);
 LAYOUT::setLayout(field_name:"associative_rel", row_num:"4", width:"1", height:"1");
 
-// Associative class
+// Associative class - some functional changes here: see issue #11699 comment history on why associative re-assignment is disabled.
+num_options = 0;
 select one assr related by r_rel->R_ASSOC[R206]->R_ASSR[R211]->R_RGO[R205]->R_OIR[R203]->O_OBJ[R201];
 select many associative_classes related by r_rel->PE_PE[R8001]->EP_PKG[R8000]->PE_PE[R8000]->O_OBJ[R8001] where (selected.Obj_ID != a_class.Obj_ID and selected.Obj_ID != b_class.Obj_ID);
 select many associative_imported_classes related by r_rel->PE_PE[R8001]->EP_PKG[R8000]->PE_PE[R8000]->O_IOBJ[R8001]->O_OBJ[R101] where (selected.Obj_ID != a_class.Obj_ID and selected.Obj_ID != b_class.Obj_ID);
 associative_classes = associative_classes + associative_imported_classes;
 default_selection = 0;
-num_options = cardinality associative_classes;
+if (empty assr)
+  num_options = cardinality associative_classes;  // just size the array at first use
+end if;
 associative_class_options[num_options] = "";
 if (0 < num_options)
   associative_class_options[num_options-1] = "";
@@ -8466,6 +8469,8 @@ if (0 < num_options)
     i = i + 1;
   end while;
   // now sorted.. see if we have an already chosen associative
+  // Note: the following is clearly redundant given the preceeding choice.
+  // - however, if re-assignment is subsequently fixed, this will be relevant.
   if not_empty assr
     i = 0;
     while ( i < (num_options) )
@@ -8477,6 +8482,8 @@ if (0 < num_options)
       i = i + 1;
     end while;
   end if;
+else
+  associative_class_options[0] = assr.Name;
 end if;
 assoc_class = USER::getDropdown(options:associative_class_options, prompt:"Associative class", default_selection:default_selection, reload_options:false);
 LAYOUT::setLayout(field_name:"assoc_class", row_num:"4", width:"1", height:"1");

--- a/src/org.xtuml.bp.core/models/org.xtuml.bp.core/ooaofooa/Functions/Context Menu Entry Functions/Context Menu Entry Functions.xtuml
+++ b/src/org.xtuml.bp.core/models/org.xtuml.bp.core/ooaofooa/Functions/Context Menu Entry Functions/Context Menu Entry Functions.xtuml
@@ -8483,7 +8483,9 @@ if (0 < num_options)
     end while;
   end if;
 else
-  associative_class_options[0] = assr.Name;
+  if (not_empty assr)
+    associative_class_options[0] = assr.Name;
+  end if;
 end if;
 assoc_class = USER::getDropdown(options:associative_class_options, prompt:"Associative class", default_selection:default_selection, reload_options:false);
 LAYOUT::setLayout(field_name:"assoc_class", row_num:"4", width:"1", height:"1");

--- a/src/org.xtuml.bp.ui.canvas/models/org.xtuml.bp.ui.canvas/ooaofgraphics/Graphical Data/Auto Reconciliation Specification/Auto Reconciliation Specification.xtuml
+++ b/src/org.xtuml.bp.ui.canvas/models/org.xtuml.bp.ui.canvas/ooaofgraphics/Graphical Data/Auto Reconciliation Specification/Auto Reconciliation Specification.xtuml
@@ -565,7 +565,7 @@ while (j < connectorCount)
     select any side2_GD_GE related by model->GD_GE[R1] where selected.elementId==side2_GD_GEId;
     if (not empty side2_GD_GE and (side2_GD_GE.connectors_created_during_reconciliation))
       // do not allow the rendered simple asssociation connector to inhibit render of link
-      if (param.passNumber != 3)
+      if (not ((param.passNumber == 3) and (self.Target_OOA_Type == OOAType::AssociativeLink)))
         connectorAlreadyCreated = true;
       end if;
     end if;

--- a/src/org.xtuml.bp.ui.canvas/models/org.xtuml.bp.ui.canvas/ooaofgraphics/Graphical Data/Auto Reconciliation Specification/Auto Reconciliation Specification.xtuml
+++ b/src/org.xtuml.bp.ui.canvas/models/org.xtuml.bp.ui.canvas/ooaofgraphics/Graphical Data/Auto Reconciliation Specification/Auto Reconciliation Specification.xtuml
@@ -41,6 +41,7 @@ return OS::NULL_UNIQUE_ID();',
 	1,
 	'',
 	"00000000-0000-0000-0000-000000000000",
+	0,
 	0);
 INSERT INTO O_TPARM
 	VALUES ("42d98f22-42d8-42d9-bcdb-0c595e38daa3",
@@ -125,6 +126,7 @@ end if;
 	1,
 	'',
 	"7c49d5b8-f700-44f4-8348-1fdcf662c1a5",
+	0,
 	0);
 INSERT INTO O_TPARM
 	VALUES ("965be58d-e2e1-4b02-a7a2-f2fddb250d11",
@@ -188,6 +190,7 @@ return OS::NULL_UNIQUE_ID();',
 	1,
 	'',
 	"01e90c90-3e42-4325-9395-f04aa3dcdeec",
+	0,
 	0);
 INSERT INTO O_TPARM
 	VALUES ("4d74bdcf-fec2-4fe9-be56-75e7e582a41f",
@@ -268,6 +271,7 @@ end for;',
 	1,
 	'',
 	"bb127757-3046-42f0-8eaa-58bc50d7f658",
+	0,
 	0);
 INSERT INTO O_TPARM
 	VALUES ("f245eb89-4c4e-47a6-9a78-6ec44ade0c95",
@@ -340,6 +344,7 @@ end while;
 	1,
 	'',
 	"c02376d4-138e-44c1-8e19-e42d4e5bdff4",
+	0,
 	0);
 INSERT INTO O_TPARM
 	VALUES ("f2156974-c155-4272-9b85-288b824e669f",
@@ -559,10 +564,13 @@ while (j < connectorCount)
     // want to create this same connector again.
     select any side2_GD_GE related by model->GD_GE[R1] where selected.elementId==side2_GD_GEId;
     if (not empty side2_GD_GE and (side2_GD_GE.connectors_created_during_reconciliation))
-      connectorAlreadyCreated = true;
+      // do not allow the rendered simple asssociation connector to inhibit render of link
+      if (param.passNumber != 3)
+        connectorAlreadyCreated = true;
+      end if;
     end if;
     
-    if (CL::traceGraphicsCreationIsEnabled()) 
+    if (CL::traceGraphicsCreationIsEnabled())
       // get side2''s name
 	  side2_ElementName = "";
 	  if (not empty side2_GD_GE) 
@@ -687,6 +695,7 @@ return OS::NULL_UNIQUE_ID();
 	1,
 	'',
 	"d4306342-68fd-418b-9c81-c7573bdd3a9b",
+	0,
 	0);
 INSERT INTO O_TPARM
 	VALUES ("cd5179d3-74a4-498f-9076-7ef3c9076490",
@@ -954,6 +963,7 @@ return reprocess;
 	1,
 	'',
 	"998fe17d-8e1a-4ed6-9b5b-cca166288747",
+	0,
 	0);
 INSERT INTO O_TPARM
 	VALUES ("1a45fe35-90f8-4600-a05b-b32b762cdc9f",
@@ -1109,6 +1119,7 @@ INSERT INTO O_TFR
 	1,
 	'',
 	"35593d44-4cf2-4d7a-ac20-1f39b82f20db",
+	0,
 	0);
 INSERT INTO O_TPARM
 	VALUES ("59e275c9-55e2-46b6-aadc-6488129b4721",
@@ -1268,6 +1279,7 @@ end if;',
 	1,
 	'',
 	"8ffad301-a127-4be7-a504-064da8b3f9dc",
+	0,
 	0);
 INSERT INTO O_TPARM
 	VALUES ("359667d7-e97c-4387-b488-8efdb1cbffdc",


### PR DESCRIPTION
1. The Binary Association editor uses Auto-graphics-reconciliation to render a 'newly-created' associative link. This is a special case when editing the association to migrate from simple to associative; the existence of the rendered 'simple' connector must not be allowed to inhibit rendering of the associative link. See detailed notes for this issue 11699.
2. Re-assign of an associative class from the editor, while handled by the association edit, is not correctly reflected on the canvas - which is misleading; hence this is disabled. Again, see issue history notes. 