### PR TITLE
Fix for 1::1 binary formalize

### DIFF
--- a/src/org.xtuml.bp.core/models/org.xtuml.bp.core/ooaofooa/Association/Association/Association.xtuml
+++ b/src/org.xtuml.bp.core/models/org.xtuml.bp.core/ooaofooa/Association/Association/Association.xtuml
@@ -1124,14 +1124,20 @@ if (not_empty simp)
       non_formalizer = b_part;
       identifier = b_identifier;
     else  // reflexive
-      reflexive_phrase = Util::substr(s:part_class, i1:0, i2:GD::strlen(s:part_class) - GD::strlen(s:a_class.Name) - 1);
-      if (reflexive_phrase == a_phrase)
-        non_formalizer = b_part;
-        identifier = b_identifier;
+      if (symmetric)  // this odd case has only a single phrase.
+        // just convert the first R_PART to a R_FORM
+        non_formalizer = b_part;     // why specify non-formalizer?...
+        identifier = a_identifier;   // but only a_identifier is valid (reflexive)
       else
-        non_formalizer = a_part;
-        identifier = a_identifier;
-      end if;
+	      reflexive_phrase = Util::substr(s:part_class, i1:0, i2:GD::strlen(s:part_class) - GD::strlen(s:a_class.Name) - 1);
+	      if (reflexive_phrase == a_phrase)
+	        non_formalizer = b_part;
+	        identifier = b_identifier;
+	      else
+	        non_formalizer = a_part;
+	        identifier = a_identifier;
+	      end if;
+	    end if;
     end if;
     simp.formalize(part_oir_id:non_formalizer.OIR_ID, id_id:identifier.Oid_ID);
   elif ("Not formalized" == part_class and self.isFormalized())

--- a/src/org.xtuml.bp.core/models/org.xtuml.bp.core/ooaofooa/Association/Class As Simple Formalizer/Class As Simple Formalizer.xtuml
+++ b/src/org.xtuml.bp.core/models/org.xtuml.bp.core/ooaofooa/Association/Class As Simple Formalizer/Class As Simple Formalizer.xtuml
@@ -19,6 +19,14 @@ Bridge:GD',
 	"ba5eda7a-def5-0000-0000-000000000004",
 	1,
 	'result = "";
+select one r_rel related by self->R_SIMP[R208]->R_REL[R206];
+if (r_rel.is_symmetric())
+  if (self.Txt_Phrs == "")
+    // formalized simple symmetric reflexives suppress the phrase in the R_FORM instance.
+    // the single association annotation will be evaluated by R_PART instance.
+    return "";
+  end if;
+end if;
 if (param.at == End::Start OR param.at == End::End)
   result = self.Txt_Phrs;
 elif (param.at == End::Start_Fixed OR param.at == End::End_Fixed)
@@ -28,6 +36,7 @@ return result;',
 	1,
 	'',
 	"f5d59a0b-dd2c-42f6-b339-9a2ab97a7677",
+	0,
 	0);
 INSERT INTO O_TPARM
 	VALUES ("c5e1d893-860d-4af0-892b-8163d964d4cb",
@@ -63,6 +72,7 @@ delete object instance self;
 	1,
 	'',
 	"00000000-0000-0000-0000-000000000000",
+	0,
 	0);
 INSERT INTO O_TFR
 	VALUES ("4b307296-cb3d-40ac-9313-3701b5a5cfa3",
@@ -77,6 +87,7 @@ return obj.Name;
 	1,
 	'',
 	"deb7beab-e808-4ed6-91e9-2d12c07524b6",
+	0,
 	0);
 INSERT INTO O_TFR
 	VALUES ("4578996f-c32c-4d90-89eb-cdaa559cdf63",
@@ -107,6 +118,7 @@ rgo.dispose();
 	1,
 	'',
 	"aa866c90-b3db-41e8-8e28-a4a692b43757",
+	0,
 	0);
 INSERT INTO O_TFR
 	VALUES ("aa866c90-b3db-41e8-8e28-a4a692b43757",
@@ -121,6 +133,7 @@ return part.Mult == 0;
 	1,
 	'',
 	"4b307296-cb3d-40ac-9313-3701b5a5cfa3",
+	0,
 	0);
 INSERT INTO O_TFR
 	VALUES ("4c846330-e6c3-41f0-a257-036961d6c1eb",
@@ -152,6 +165,7 @@ delete object instance self;
 	1,
 	'',
 	"4578996f-c32c-4d90-89eb-cdaa559cdf63",
+	0,
 	0);
 INSERT INTO O_REF
 	VALUES ("04bd0a38-9559-4ea0-9ff0-cf445e373e21",

--- a/src/org.xtuml.bp.core/models/org.xtuml.bp.core/ooaofooa/Association/Class As Simple Participant/Class As Simple Participant.xtuml
+++ b/src/org.xtuml.bp.core/models/org.xtuml.bp.core/ooaofooa/Association/Class As Simple Participant/Class As Simple Participant.xtuml
@@ -23,9 +23,9 @@ Bridge:GD
 select one r_rel related by self->R_SIMP[R207]->R_REL[R206];
 if (r_rel.is_symmetric())
   if (self.Txt_Phrs == "")
-  	// simple symmetric reflexives suppress the phrase in one of the R_PART instances
+  	// unformalized simple symmetric reflexives suppress the phrase in one of the R_PART instances
   	// this, then, is the ''empty'' side for phrase/mult/cond annotation of the asssociation.
-  	// the association annotation will be evaluated by the other ''side'' R_PART
+  	// the single association annotation will be evaluated by the other ''side'' R_PART
     return "";
   end if;
 end if;

--- a/src/org.xtuml.bp.core/models/org.xtuml.bp.core/ooaofooa/Functions/Context Menu Entry Functions/Context Menu Entry Functions.xtuml
+++ b/src/org.xtuml.bp.core/models/org.xtuml.bp.core/ooaofooa/Functions/Context Menu Entry Functions/Context Menu Entry Functions.xtuml
@@ -8568,9 +8568,6 @@ if (a_cond == "Unconditionally" and b_cond == "Conditionally")  // prefer the un
   participants[0] = a_to_b_part;
 end if;
 default_selection = 0;
-if (r_rel.isFormalized() and not_empty a_form)
-  default_selection = 1;
-end if;
 
 // establish whether formalization is possible
 can_formalize = true;


### PR DESCRIPTION
Fix formalization choices for symmetric.
Delete bad default selection: dated back to "Not formalized" choice.