### PR TITLE
Eliminate warnings provided by newer Eclipse

### DIFF
--- a/src/org.xtuml.bp.ui.marking/.project
+++ b/src/org.xtuml.bp.ui.marking/.project
@@ -53,7 +53,6 @@
 	<natures>
     <nature>org.xtuml.bp.core.xtumlnature</nature>
 		<nature>org.xtuml.bp.mc.java.mcjavanature</nature>
-		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
 </projectDescription>

--- a/src/org.xtuml.bp.ui.marking/.settings/org.eclipse.core.resources.prefs
+++ b/src/org.xtuml.bp.ui.marking/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8


### PR DESCRIPTION
Add explicit encoding set to and remove an unknown nature from the marking project.
https://support.onefact.net/issues/12643