### PR TITLE
Revert "job #12782: update eclipse build to avoid macos swt bug"

### DIFF
--- a/releng/org.xtuml.bp.releng.parent/pom.xml
+++ b/releng/org.xtuml.bp.releng.parent/pom.xml
@@ -20,14 +20,14 @@
 
 	<repositories>
 		<repository>
-			<id>2024-03</id>
+			<id>2022-06</id>
 			<layout>p2</layout>
-			<url>https://download.eclipse.org/releases/2024-03/</url>
+			<url>https://download.eclipse.org/releases/2023-12/</url>
 		</repository>
 		<repository>
-			<id>4.32-I-builds</id>
+			<id>4.30-update</id>
 			<layout>p2</layout>
-      <url>https://download.eclipse.org/eclipse/updates/4.32-I-builds/I20240311-1800/</url>
+      <url>https://download.eclipse.org/eclipse/updates/4.30/</url>
 		</repository>
 		<repository>
 			<id>antlr</id>


### PR DESCRIPTION
Reverts xtuml/bridgepoint#871

This PR caused some graphical issues on BP diagrams that need to be resolved before it can be merged into master.