### PR TITLE
Update Eclipse platform versions

### DIFF
--- a/releng/org.xtuml.bp.mctools.parent/pom.xml
+++ b/releng/org.xtuml.bp.mctools.parent/pom.xml
@@ -8,7 +8,7 @@
   <packaging>pom</packaging>
 
   <properties>
-    <tycho-version>4.0.4</tycho-version>
+    <tycho-version>4.0.9</tycho-version>
   </properties>
 
   <modules>

--- a/releng/org.xtuml.bp.releng.parent.product-dev/bridgepoint-dev.product
+++ b/releng/org.xtuml.bp.releng.parent.product-dev/bridgepoint-dev.product
@@ -91,7 +91,7 @@
 
    <repositories>
       <repository location="http://download.eclipse.org/technology/m2e/releases" enabled="false" />
-      <repository location="https://download.eclipse.org/releases/2020-06/" enabled="true" />
+      <repository location="https://download.eclipse.org/releases/2024-12/" enabled="true" />
    </repositories>
 
    <preferencesInfo>

--- a/releng/org.xtuml.bp.releng.parent.product-dev/p2.inf
+++ b/releng/org.xtuml.bp.releng.parent.product-dev/p2.inf
@@ -1,3 +1,3 @@
 instructions.configure = \
- chmod(targetDir:${installFolder}/plugins/org.apache.ant_1.10.14.v20230922-1200/bin,targetFile:ant,permissions:755); \
- chmod(targetDir:${installFolder}/plugins/org.apache.ant_1.10.14.v20230922-1200/bin,targetFile:antRun,permissions:755);
+ chmod(targetDir:${installFolder}/plugins/org.apache.ant_1.10.15.v20240901-1000/bin,targetFile:ant,permissions:755); \
+ chmod(targetDir:${installFolder}/plugins/org.apache.ant_1.10.15.v20240901-1000/bin,targetFile:antRun,permissions:755);

--- a/releng/org.xtuml.bp.releng.parent.product/bridgepoint.product
+++ b/releng/org.xtuml.bp.releng.parent.product/bridgepoint.product
@@ -89,7 +89,7 @@
    </configurations>
 
    <repositories>
-      <repository location="https://download.eclipse.org/releases/2020-06/" enabled="true" />
+      <repository location="https://download.eclipse.org/releases/2024-12/" enabled="true" />
    </repositories>
 
    <preferencesInfo>

--- a/releng/org.xtuml.bp.releng.parent.product/p2.inf
+++ b/releng/org.xtuml.bp.releng.parent.product/p2.inf
@@ -1,3 +1,3 @@
 instructions.configure = \
- chmod(targetDir:${installFolder}/plugins/org.apache.ant_1.10.14.v20230922-1200/bin,targetFile:ant,permissions:755); \
- chmod(targetDir:${installFolder}/plugins/org.apache.ant_1.10.14.v20230922-1200/bin,targetFile:antRun,permissions:755);
+ chmod(targetDir:${installFolder}/plugins/org.apache.ant_1.10.15.v20240901-1000/bin,targetFile:ant,permissions:755); \
+ chmod(targetDir:${installFolder}/plugins/org.apache.ant_1.10.15.v20240901-1000/bin,targetFile:antRun,permissions:755);

--- a/releng/org.xtuml.bp.releng.parent/pom.xml
+++ b/releng/org.xtuml.bp.releng.parent/pom.xml
@@ -9,7 +9,7 @@
 	<packaging>pom</packaging>
 
 	<properties>
-		<tycho-version>4.0.4</tycho-version>
+		<tycho-version>4.0.9</tycho-version>
 		<ant-home-path>${env.ANT_HOME}</ant-home-path>
 		<eclipse-home-path>${env.bp_install_dir}</eclipse-home-path>
 		<mcj_path>../../src/MC-Java</mcj_path>
@@ -20,25 +20,24 @@
 
 	<repositories>
 		<repository>
-			<id>2022-06</id>
+			<id>2024-12</id>
 			<layout>p2</layout>
-			<url>https://download.eclipse.org/releases/2023-12/</url>
+			<url>https://download.eclipse.org/releases/2024-12/</url>
 		</repository>
 		<repository>
-			<id>4.30-update</id>
+			<id>4.34-update</id>
 			<layout>p2</layout>
-      <url>https://download.eclipse.org/eclipse/updates/4.30/</url>
+      <url>https://download.eclipse.org/eclipse/updates/4.34/</url>
 		</repository>
 		<repository>
 			<id>antlr</id>
 			<layout>p2</layout>
-			<!--<url>file:////build/buildmt/repository</url>-->
 			<url>https://s3.amazonaws.com/1f-outgoing/antlr_upsite/</url>
 		</repository>
 		<repository>
-			<id>cdt-11.4.0</id>
+			<id>cdt-11.6</id>
 			<layout>p2</layout>
-			<url>https://download.eclipse.org/tools/cdt/releases/11.4/</url>
+			<url>https://download.eclipse.org/tools/cdt/releases/11.6/</url>
 		</repository>
 	</repositories>
 	

--- a/src/org.xtuml.bp.ui.graphics/src/org/xtuml/bp/ui/graphics/policies/ConnectorBendPointEditPolicy.java
+++ b/src/org.xtuml.bp.ui.graphics/src/org/xtuml/bp/ui/graphics/policies/ConnectorBendPointEditPolicy.java
@@ -65,7 +65,7 @@ public class ConnectorBendPointEditPolicy extends BendpointEditPolicy {
 	}
 
 	@Override
-	protected List<?> createSelectionHandles() {
+	protected List createSelectionHandles() {
 		List<BendpointHandle> list = new ArrayList<BendpointHandle>();
 		ConnectionEditPart connEP = (ConnectionEditPart) getHost();
 		PointList points = getConnection().getPoints();

--- a/src/org.xtuml.bp.ui.graphics/src/org/xtuml/bp/ui/graphics/policies/ConnectorEndpointEditPolicy.java
+++ b/src/org.xtuml.bp.ui.graphics/src/org/xtuml/bp/ui/graphics/policies/ConnectorEndpointEditPolicy.java
@@ -22,7 +22,7 @@ public class ConnectorEndpointEditPolicy extends ConnectionEndpointEditPolicy {
 	}
 
 	@Override
-	protected List<?> createSelectionHandles() {
+	protected List createSelectionHandles() {
 		fPreviousLineWidth = ((PolylineConnection) getHostFigure())
 				.getLineWidth();
 		if (fPreviousLineWidth == 0) {

--- a/src/org.xtuml.bp.ui.graphics/src/org/xtuml/bp/ui/graphics/policies/ConnectorMoveEditPolicy.java
+++ b/src/org.xtuml.bp.ui.graphics/src/org/xtuml/bp/ui/graphics/policies/ConnectorMoveEditPolicy.java
@@ -277,7 +277,7 @@ public class ConnectorMoveEditPolicy extends NonResizableEditPolicy {
 	}
 
 	@Override
-	protected List<?> createSelectionHandles() {
+	protected List createSelectionHandles() {
 		return Collections.EMPTY_LIST;
 	}
 

--- a/src/org.xtuml.bp.ui.graphics/src/org/xtuml/bp/ui/graphics/policies/TextResizableEditPolicy.java
+++ b/src/org.xtuml.bp.ui.graphics/src/org/xtuml/bp/ui/graphics/policies/TextResizableEditPolicy.java
@@ -176,7 +176,7 @@ public class TextResizableEditPolicy extends ResizableEditPolicy {
 	}
 
 	@Override
-	protected List<Handle> createSelectionHandles() {
+	protected List createSelectionHandles() {
 		List<Handle> list = new ArrayList<Handle>();
 		MoveHandle moveHandle = new MoveHandle((GraphicalEditPart) getHost());
 		moveHandle.setDragTracker(new TextDragEditPartsTracker(getHost()));

--- a/src/org.xtuml.bp.ui.graphics/src/org/xtuml/bp/ui/graphics/trackers/TextDragEditPartsTracker.java
+++ b/src/org.xtuml.bp.ui.graphics/src/org/xtuml/bp/ui/graphics/trackers/TextDragEditPartsTracker.java
@@ -58,7 +58,7 @@ public class TextDragEditPartsTracker extends DragEditPartsTracker {
 	}
 
 	@Override
-	protected List<Object> createOperationSet() {
+	protected List createOperationSet() {
 		if (getCurrentViewer() != null) {
 			List<?> list = ToolUtilities
 					.getSelectionWithoutDependants(getCurrentViewer());
@@ -66,7 +66,7 @@ public class TextDragEditPartsTracker extends DragEditPartsTracker {
 			// they are always selected along with
 			// the parent, but as a secondary selection
 			// according to GEF
-			List<Object> additionalSelection = new ArrayList<Object>();
+			List additionalSelection = new ArrayList<Object>();
 			additionalSelection.addAll(list);
 			for (Object selected : list) {
 				EditPart part = (EditPart) selected;

--- a/src/org.xtuml.bp.ui.graphics/src/org/xtuml/bp/ui/graphics/trackers/TextResizeTracker.java
+++ b/src/org.xtuml.bp.ui.graphics/src/org/xtuml/bp/ui/graphics/trackers/TextResizeTracker.java
@@ -49,13 +49,13 @@ public class TextResizeTracker extends ResizeTracker {
 	}
 
 	@Override
-	protected List<?> createOperationSet() {
+	protected List createOperationSet() {
 		List<?> list = getCurrentViewer().getSelectedEditParts();
 		// add any text edit parts if existing
 		// they are always selected along with
 		// the parent, but as a secondary selection
 		// according to GEF
-		List<Object> additionalSelection = new ArrayList<Object>();
+		List additionalSelection = new ArrayList<Object>();
 		additionalSelection.addAll(list);
 		for (Object selected : list) {
 			EditPart part = (EditPart) selected;

--- a/src/org.xtuml.bp.xtext.masl.parent/pom.xml
+++ b/src/org.xtuml.bp.xtext.masl.parent/pom.xml
@@ -14,7 +14,7 @@
 
 
 	<properties>
-		<tycho-version>4.0.4</tycho-version>
+		<tycho-version>4.0.9</tycho-version>
 		<xtextVersion>2.33.0</xtextVersion>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>

--- a/src/org.xtuml.canvas.language.parent/pom.xml
+++ b/src/org.xtuml.canvas.language.parent/pom.xml
@@ -16,7 +16,7 @@
 		<mwe2Version>2.16.0</mwe2Version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<!-- Tycho settings -->
-		<tycho-version>4.0.4</tycho-version>
+		<tycho-version>4.0.9</tycho-version>
 		<!-- Define overridable properties for tycho-surefire-plugin -->
 		<platformSystemProperties></platformSystemProperties>
 		<moduleProperties></moduleProperties>


### PR DESCRIPTION
This updates everything to the 12/2025 release versions. It also resolves issue #12782 in which graphics were messed up on Mac, preventing the ability to do interactive debugging.